### PR TITLE
fix: reference to invalid element

### DIFF
--- a/includes/bit-byte-converter.h
+++ b/includes/bit-byte-converter.h
@@ -9,6 +9,7 @@
 /// \privatesection
 int gets();
 /// \publicsection
+#include <cstddef>
 #include <vector>
 #include <map>
 #include <utility>
@@ -24,14 +25,14 @@ namespace ResearchLibrary {
 
 /// \class BitsToBytes
 /// \brief converts bit stream to byte stream
-template <size_t N>
+template <std::size_t N>
 class BitsToBytes {
  private:
   std::vector<uint8_t> data;
-  size_t buffered_length;
+  std::size_t buffered_length;
   uint8_t buffered_bits;
 
-  size_type_t<N> mask(size_t n) {
+  size_type_t<N> mask(std::size_t n) {
     return (size_type_t<N>(1) << n) - 1;
   }
 
@@ -42,7 +43,7 @@ class BitsToBytes {
   /// \brief put a bits to the stream
   /// \param[in] value contains bit-stream
   /// \param[in] length length of the bit-stream
-  void put(size_type_t<N> value, size_t length) {
+  void put(size_type_t<N> value, std::size_t length) {
     value &= mask(length);
     if (buffered_length + length >= 8) {
       // | <-   value  -> | <- buffered -> |
@@ -79,14 +80,14 @@ class BitsToBytes {
 
 /// \class BytesToBits
 /// \brief converts byte stream to bit stream
-template <size_t N>
+template <std::size_t N>
 class BytesToBits {
  private:
   std::vector<uint8_t> buffer;
-  size_t data_index, buffered_length;
+  std::size_t data_index, buffered_length;
   size_type_t<N> buffered_bits;
 
-  size_type_t<N> mask(size_t n) {
+  size_type_t<N> mask(std::size_t n) {
     return (size_type_t<N>(1) << n) - 1;
   }
 
@@ -110,9 +111,9 @@ class BytesToBits {
     return;
   }
 
-  /// \fn get(size_t length)
+  /// \fn get(std::size_t length)
   /// \brief get a value from the stream
-  size_type_t<N> get(size_t length) {
+  size_type_t<N> get(std::size_t length) {
     if (length > buffered_length) {
       // | <- buffer -> | <- buffered bits -> |
       // | <- rest -> | <-      value      -> |
@@ -141,15 +142,15 @@ class BytesToBits {
     }
   }
 
-  /// \fn fetch(size_t length)
+  /// \fn fetch(std::size_t length)
   /// \brief fetch a value from the stream
-  size_type_t<N> fetch(size_t length) const {
+  size_type_t<N> fetch(std::size_t length) const {
     if (length > buffered_length) {
       auto value = buffered_bits;
       auto stored_length = buffered_length;
       length -= buffered_length;
       auto index = data_index;
-      size_t extra_read_length = 0;
+      std::size_t extra_read_length = 0;
       size_type_t<N> extra_buffer = 0;
       while (length > extra_read_length) {
         extra_buffer |= size_type_t<N>(buffer[index]) << extra_read_length;

--- a/includes/burrows-wheeler-transform.h
+++ b/includes/burrows-wheeler-transform.h
@@ -9,6 +9,7 @@
 /// \privatesection
 int gets();
 /// \publicsection
+#include <cstddef>
 #include <vector>
 #include <utility>
 #include <algorithm>
@@ -30,20 +31,20 @@ bool ge(T x, T y) {
 
 template <typename T>
 auto suffix_sort_for_BWT(const std::vector<T>& source) {
-  constexpr auto SORTED_FLAG = size_t(1) << (sizeof(size_t) * 8 - 1);
+  constexpr auto SORTED_FLAG = std::size_t(1) << (sizeof(std::size_t) * 8 - 1);
   constexpr auto MASK = ~SORTED_FLAG;
   const auto N = source.size();
-  std::vector<size_t> I(N), V(N);
-  for (size_t i = 0; i < N; i++) {
+  std::vector<std::size_t> I(N), V(N);
+  for (std::size_t i = 0; i < N; i++) {
     I[i] = i;
   }
-  std::stable_sort(I.begin(), I.end(), [=](size_t x, size_t y) {
+  std::stable_sort(I.begin(), I.end(), [=](std::size_t x, std::size_t y) {
     return source[x] < source[y];
   });
   {
     auto last_character = source[I[0]];
-    size_t g = 0;
-    for (size_t i = N - 1; ge(i, decltype(i)(0)); i--) {
+    std::size_t g = 0;
+    for (std::size_t i = N - 1; ge(i, decltype(i)(0)); i--) {
       if (last_character != source[I[i]]) {
         g = i;
         last_character = source[I[i]];
@@ -51,16 +52,16 @@ auto suffix_sort_for_BWT(const std::vector<T>& source) {
       V[I[i]] = g;
     }
   }
-  for (size_t i = 0; i < N;) {
+  for (std::size_t i = 0; i < N;) {
     auto group = V[I[i]];
     if (i == group) {
       I[i] = SORTED_FLAG + 1;
     }
     i = group + 1;
   }
-  size_t h = 1;
+  std::size_t h = 1;
   while (h <= N) {
-    size_t first_position = 0, group_start_index = 0;
+    std::size_t first_position = 0, group_start_index = 0;
     bool sorted_sequence = false;
     do {
       if ((I[first_position] & SORTED_FLAG) != 0) {
@@ -78,7 +79,7 @@ auto suffix_sort_for_BWT(const std::vector<T>& source) {
         auto last_position = V[I[first_position]];
         std::sort(&I[first_position],
                   &I[last_position] + 1,
-                  [=](size_t x, size_t y) {
+                  [=](std::size_t x, std::size_t y) {
           return V[(x + h) % N] < V[(y + h) % N];
         });
         auto group = last_position;
@@ -109,7 +110,7 @@ auto suffix_sort_for_BWT(const std::vector<T>& source) {
     h <<= 1;
   }
 
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     I[V[i]] = i;
   }
   return I;
@@ -120,18 +121,18 @@ auto suffix_sort_for_BWT(const std::vector<T>& source) {
 /// \brief Burrows-Wheeler Transform Function
 /// \param[in] source sequence
 /// \return \c std::pair of
-///         sorted sequence as \c std::vector<T> and index as \c size_t
+///         sorted sequence as \c std::vector<T> and index as \c std::size_t
 template <typename T>
 auto BWT(const std::vector<T>& source) {
   if (source.size() == 0) {
-    return std::make_pair(std::vector<T>(), static_cast<size_t>(0));
+    return std::make_pair(std::vector<T>(), static_cast<std::size_t>(0));
   } else if (source.size() == 1) {
-    return std::make_pair(source, static_cast<size_t>(0));
+    return std::make_pair(source, static_cast<std::size_t>(0));
   }
   auto&& suffix_array = suffix_sort_for_BWT(source);
-  size_t index;
+  std::size_t index;
   std::vector<T> ret(source.size());
-  for (size_t i = 0; i < suffix_array.size(); i++) {
+  for (std::size_t i = 0; i < suffix_array.size(); i++) {
     if (suffix_array[i] == 0) {
       index = i;
     }
@@ -140,19 +141,19 @@ auto BWT(const std::vector<T>& source) {
   return std::make_pair(std::move(ret), index);
 }
 
-/// \fn IBWT(const std::vector<T>& source, size_t index)
+/// \fn IBWT(const std::vector<T>& source, std::size_t index)
 /// \brief Inverse Burrows-Wheeler Transform Function
 /// \param[in] source sorted sequence
 /// \param[in] index The index
 /// \return deconverted sequence as \c std::vector<T>
 template <typename T>
-auto IBWT(const std::vector<T>& source, size_t index) {
+auto IBWT(const std::vector<T>& source, std::size_t index) {
   const auto N = source.size();
-  std::vector<size_t> buffer(N);
-  for (size_t i = 0; i < N; i++) {
+  std::vector<std::size_t> buffer(N);
+  for (std::size_t i = 0; i < N; i++) {
     buffer[i] = i;
   }
-  std::stable_sort(buffer.begin(), buffer.end(), [=](size_t x, size_t y) {
+  std::stable_sort(buffer.begin(), buffer.end(), [=](std::size_t x, std::size_t y) {
     return source[x] < source[y];
   });
   std::vector<T> ret{};
@@ -163,13 +164,13 @@ auto IBWT(const std::vector<T>& source, size_t index) {
   return ret;
 }
 
-/// \fn IBWT(const std::pair<std::vector<T>, size_t>& source)
+/// \fn IBWT(const std::pair<std::vector<T>, std::size_t>& source)
 /// \brief Inverse Burrows-Wheeler Transform Function
 /// \param[in] source \c std::pair of sorted sequence as
-///            \c std::vector<T> and index as \c size_t
+///            \c std::vector<T> and index as \c std::size_t
 /// \return deconverted sequence as \c std::vector<T>
 template <typename T>
-auto IBWT(const std::pair<std::vector<T>, size_t>& source) {
+auto IBWT(const std::pair<std::vector<T>, std::size_t>& source) {
   return IBWT(source.first, source.second);
 }
 

--- a/includes/discrete-cosine-transform.h
+++ b/includes/discrete-cosine-transform.h
@@ -6,6 +6,7 @@
 #ifndef INCLUDES_DISCRETE_COSINE_TRANSFORM_H_
 #define INCLUDES_DISCRETE_COSINE_TRANSFORM_H_
 
+#include <cstddef>
 #include <vector>
 
 #ifdef RESEARCHLIB_OFFLINE_TEST
@@ -27,7 +28,7 @@ template <typename T>
 auto DCT(const std::vector<T>& data) {
   auto N = data.size() * 4;
   std::vector<T> re(N, 0), im(N, 0);
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     re[2 * i + 1] = re[N - 2 * i - 1] = data[i];
   }
   auto&& ret = FastFourierTransform::FFT(re, im).first;
@@ -45,12 +46,12 @@ auto IDCT(const std::vector<T>& data) {
   std::vector<T> re(N, 0), im(N, 0);
   re[0] = data[0];
   re[N / 2] = -data[0];
-  for (size_t i = 1; i < data.size(); i++) {
+  for (std::size_t i = 1; i < data.size(); i++) {
     re[i] = re[N - i] = data[i];
     re[N / 2 + i] = re[N / 2 - i] = -data[i];
   }
   auto&& ret = FastFourierTransform::IFFT(re, im).first;
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     ret[i] = ret[2 * i + 1];
   }
   ret.resize(data.size());

--- a/includes/discrete-wavelet-transform.h
+++ b/includes/discrete-wavelet-transform.h
@@ -6,6 +6,7 @@
 #ifndef INCLUDES_DISCRETE_WAVELET_TRANSFORM_H_
 #define INCLUDES_DISCRETE_WAVELET_TRANSFORM_H_
 
+#include <cstddef>
 #include <vector>
 #include <utility>
 
@@ -23,7 +24,7 @@ template <typename T>
 auto Haar(const std::vector<T>& data) {
   auto N = data.size() / 2;
   std::vector<T> approxim(N), detail(N);
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     approxim[i] = data[2 * i] + data[2 * i + 1];
     detail[i]   = data[2 * i] - data[2 * i + 1];
   }
@@ -39,7 +40,7 @@ template <typename T>
 auto IHaar(const std::vector<T>& approxim, const std::vector<T>& detail) {
   auto N = approxim.size();
   std::vector<T> ret(2 * N);
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     ret[2 * i] = (approxim[i] + detail[i]) / 2;
     ret[2 * i + 1] = (approxim[i] - detail[i]) / 2;
   }
@@ -66,14 +67,14 @@ auto CDF53(const std::vector<T>& data) {
   constexpr auto b = 0.25;
   auto N = data.size() / 2;
   std::vector<T> even(N), odd(N);
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     even[i] = data[2 * i];
     odd[i] = data[2 * i + 1];
   }
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     odd[i] += a * (even[i] + even[(i + 1) % N]);
   }
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     even[i] += b * (odd[i] + odd[(i - 1 + N) % N]);
   }
   return std::make_pair(std::move(even), std::move(odd));
@@ -90,18 +91,18 @@ auto ICDF53(const std::vector<T>& approxim, const std::vector<T>& detail) {
   constexpr auto b = 0.25;
   auto N = approxim.size();
   std::vector<T> even(N), odd(N);
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     even[i] = approxim[i];
     odd[i] = detail[i];
   }
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     even[i] -= b * (odd[i] + odd[(i - 1 + N) % N]);
   }
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     odd[i] -= a * (even[i] + even[(i + 1) % N]);
   }
   std::vector<T> ret(2 * N);
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     ret[2 * i] = even[i];
     ret[2 * i + 1] = odd[i];
   }
@@ -130,20 +131,20 @@ auto CDF97(const std::vector<T>& data) {
   constexpr auto d = 0.4435068520511142;
   auto N = data.size() / 2;
   std::vector<T> even(N), odd(N);
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     even[i] = data[2 * i];
     odd[i] = data[2 * i + 1];
   }
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     odd[i] += a * (even[i] + even[(i + 1) % N]);
   }
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     even[i] += b * (odd[i] + odd[(i - 1 + N) % N]);
   }
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     odd[i] += c * (even[i] + even[(i + 1) % N]);
   }
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     even[i] += d * (odd[i] + odd[(i - 1 + N) % N]);
   }
   return std::make_pair(std::move(even), std::move(odd));
@@ -162,24 +163,24 @@ auto ICDF97(const std::vector<T>& approxim, const std::vector<T>& detail) {
   constexpr auto d = 0.4435068520511142;
   auto N = approxim.size();
   std::vector<T> even(N), odd(N);
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     even[i] = approxim[i];
     odd[i] = detail[i];
   }
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     even[i] -= d * (odd[i] + odd[(i - 1 + N) % N]);
   }
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     odd[i] -= c * (even[i] + even[(i + 1) % N]);
   }
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     even[i] -= b * (odd[i] + odd[(i - 1 + N) % N]);
   }
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     odd[i] -= a * (even[i] + even[(i + 1) % N]);
   }
   std::vector<T> ret(2 * N);
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     ret[2 * i] = even[i];
     ret[2 * i + 1] = odd[i];
   }

--- a/includes/fast-fourier-transform.h
+++ b/includes/fast-fourier-transform.h
@@ -9,6 +9,7 @@
 /// \privatesection
 int gets();
 /// \publicsection
+#include <cstddef>
 #include <vector>
 #include <map>
 #include <utility>
@@ -27,20 +28,20 @@ namespace ResearchLibrary {
 namespace FastFourierTransform {
 
 /// \privatesection
-template <size_t N>
+template <std::size_t N>
 auto width_map() {
-  std::map<size_type_t<N>, size_t> w;
-  for (size_t i = 0; i < N * 8; i++) {
+  std::map<size_type_t<N>, std::size_t> w;
+  for (std::size_t i = 0; i < N * 8; i++) {
     w[size_type_t<N>(1) << i] = i;
   }
   return w;
 }
 
-template <size_t N>
-size_type_t<N> upside_down(size_type_t<N> x, size_t width);
+template <std::size_t N>
+size_type_t<N> upside_down(size_type_t<N> x, std::size_t width);
 
 template <>
-size_type_t<1> upside_down<1>(size_type_t<1> x, size_t width) {
+size_type_t<1> upside_down<1>(size_type_t<1> x, std::size_t width) {
   x = size_type_t<1>((x & 0x55) << 1) | size_type_t<1>((x & 0xaa) >> 1);
   x = size_type_t<1>((x & 0x33) << 2) | size_type_t<1>((x & 0xcc) >> 2);
   x = size_type_t<1>((x & 0x0f) << 4) | size_type_t<1>((x & 0xf0) >> 4);
@@ -48,7 +49,7 @@ size_type_t<1> upside_down<1>(size_type_t<1> x, size_t width) {
 }
 
 template <>
-size_type_t<2> upside_down<2>(size_type_t<2> x, size_t width) {
+size_type_t<2> upside_down<2>(size_type_t<2> x, std::size_t width) {
   x = size_type_t<2>((x & 0x5555) << 1) | size_type_t<2>((x & 0xaaaa) >> 1);
   x = size_type_t<2>((x & 0x3333) << 2) | size_type_t<2>((x & 0xcccc) >> 2);
   x = size_type_t<2>((x & 0x0f0f) << 4) | size_type_t<2>((x & 0xf0f0) >> 4);
@@ -57,7 +58,7 @@ size_type_t<2> upside_down<2>(size_type_t<2> x, size_t width) {
 }
 
 template <>
-size_type_t<4> upside_down<4>(size_type_t<4> x, size_t width) {
+size_type_t<4> upside_down<4>(size_type_t<4> x, std::size_t width) {
   x = ((x & 0x55555555) << 1)  | ((x & 0xaaaaaaaa) >> 1);
   x = ((x & 0x33333333) << 2)  | ((x & 0xcccccccc) >> 2);
   x = ((x & 0x0f0f0f0f) << 4)  | ((x & 0xf0f0f0f0) >> 4);
@@ -67,7 +68,7 @@ size_type_t<4> upside_down<4>(size_type_t<4> x, size_t width) {
 }
 
 template <>
-size_type_t<8> upside_down<8>(size_type_t<8> x, size_t width) {
+size_type_t<8> upside_down<8>(size_type_t<8> x, std::size_t width) {
   x = ((x & 0x5555555555555555) << 1)  | ((x & 0xaaaaaaaaaaaaaaaa) >> 1);
   x = ((x & 0x3333333333333333) << 2)  | ((x & 0xcccccccccccccccc) >> 2);
   x = ((x & 0x0f0f0f0f0f0f0f0f) << 4)  | ((x & 0xf0f0f0f0f0f0f0f0) >> 4);
@@ -86,21 +87,21 @@ size_type_t<8> upside_down<8>(size_type_t<8> x, size_t width) {
 template <typename T>
 auto FFT(const std::vector<T>& re, const std::vector<T>& im) {
   auto N = re.size();
-  auto width = width_map<sizeof(size_t)>()[N];
+  auto width = width_map<sizeof(std::size_t)>()[N];
   std::vector<T> t1re(N), t1im(N), t2re(N), t2im(N), c(N), s(N);
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     c[i] = cos(2 * M_PI * i / N);
     s[i] = -sin(2 * M_PI * i / N);
-    auto j = upside_down<sizeof(size_t)>(i, width);
+    auto j = upside_down<sizeof(std::size_t)>(i, width);
     t1re[i] = re[j];
     t1im[i] = im[j];
   }
-  for (size_t n = 1; n < N; n <<= 1) {
+  for (std::size_t n = 1; n < N; n <<= 1) {
     std::swap(t1re, t2re);
     std::swap(t1im, t2im);
     auto k = N / n / 2;
-    for (size_t i = 0; i < N; i += 2 * n) {
-      for (size_t j = 0; j < n; j++) {
+    for (std::size_t i = 0; i < N; i += 2 * n) {
+      for (std::size_t j = 0; j < n; j++) {
         auto cij = c[(i + j) * k % N], sij = s[(i + j) * k % N];
         auto cijn = c[(i + j + n) * k % N], sijn = s[(i + j + n) * k % N];
         t1re[i + j]     = t2re[i + j] + t2re[i + j + n] * cij
@@ -125,18 +126,18 @@ auto FFT(const std::vector<T>& re, const std::vector<T>& im) {
 template <typename T>
 auto FFT(const std::vector<std::complex<T>>& data) {
   auto N = data.size();
-  auto width = width_map<sizeof(size_t)>()[N];
+  auto width = width_map<sizeof(std::size_t)>()[N];
   std::vector<std::complex<T>> t1(N), t2(N), e(N);
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     e[i] = std::complex<T>(cos(2 * M_PI * i / N), -sin(2 * M_PI * i / N));
-    auto j = upside_down<sizeof(size_t)>(i, width);
+    auto j = upside_down<sizeof(std::size_t)>(i, width);
     t1[i] = data[j];
   }
-  for (size_t n = 1; n < N; n <<= 1) {
+  for (std::size_t n = 1; n < N; n <<= 1) {
     std::swap(t1, t2);
     auto k = N / n / 2;
-    for (size_t i = 0; i < N; i += 2 * n) {
-      for (size_t j = 0; j < n; j++) {
+    for (std::size_t i = 0; i < N; i += 2 * n) {
+      for (std::size_t j = 0; j < n; j++) {
         t1[i + j]     = t2[i + j] + t2[i + j + n] * e[(i + j) * k % N];
         t1[i + j + n] = t2[i + j] + t2[i + j + n] * e[(i + j + n) * k % N];
       }

--- a/includes/move-to-front.h
+++ b/includes/move-to-front.h
@@ -146,8 +146,8 @@ auto IMTF(const std::vector<unsigned_integer_t>& sequence,
         if (p == 0) {
           auto&& w = *it;
           ret.push_back(w);
+          dictionary.push_front(std::move(w));
           dictionary.erase(it);
-          dictionary.push_front(w);
           break;
         }
         p--;
@@ -195,8 +195,8 @@ auto IMTF(const std::vector<unsigned_integer_t>& sequence,
         if (p == 0) {
           auto&& w = *it;
           ret.push_back(w);
+          dictionary.push_front(std::move(w));
           dictionary.erase(it);
-          dictionary.push_front(w);
           break;
         }
         p--;
@@ -244,8 +244,8 @@ auto NumericIMTF(const std::vector<unsigned_integer_t>& sequence) {
         if (p == 0) {
           auto&& w = *it;
           ret.push_back(w);
+          dictionary.push_front(std::move(w));
           dictionary.erase(it);
-          dictionary.push_front(w);
           break;
         }
         p--;

--- a/includes/move-to-front.h
+++ b/includes/move-to-front.h
@@ -34,7 +34,7 @@ auto MTF(const std::vector<T>& data) {
   std::vector<T> raw{};
   std::vector<unsigned_integer_t> sequence{};
 
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     auto&& w = data[i];
     unsigned_integer_t p = 0;
     for (auto it = dictionary.begin(); it != dictionary.end(); ++it) {
@@ -56,18 +56,18 @@ auto MTF(const std::vector<T>& data) {
   return std::make_pair(std::move(sequence), std::move(raw));
 }
 
-/// \fn MTF(const std::vector<T>& data, size_t dictionary_max_size)
+/// \fn MTF(const std::vector<T>& data, std::size_t dictionary_max_size)
 /// \brief Original Move-to-Front Function
 /// \param[in] data sequence
 /// \param[in] dictionary_max_size maximum size of the dictionary
 /// \return std::pair of MTF-ed sequence and dictionary as std::list<T>
 template <typename T>
-auto MTF(const std::vector<T>& data, size_t dictionary_max_size) {
+auto MTF(const std::vector<T>& data, std::size_t dictionary_max_size) {
   std::list<T> dictionary{};
   std::vector<T> raw{};
   std::vector<unsigned_integer_t> sequence{};
 
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     auto&& w = data[i];
     unsigned_integer_t p = 0;
     for (auto it = dictionary.begin(); it != dictionary.end(); ++it) {
@@ -102,9 +102,9 @@ auto NumericMTF(const std::vector<T>& data) {
   std::list<T> dictionary{};
   std::vector<unsigned_integer_t> sequence{};
 
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     auto&& w = data[i];
-    if (size_t(w) < dictionary.size()) {
+    if (std::size_t(w) < dictionary.size()) {
       unsigned_integer_t p = 0;
       for (auto&& it = dictionary.begin(); it != dictionary.end(); ++it) {
         if (*it == w) {
@@ -138,8 +138,8 @@ auto IMTF(const std::vector<unsigned_integer_t>& sequence,
           const std::vector<T>& raw) {
   std::list<T> dictionary{};
   std::vector<T> ret{};
-  size_t raw_index = 0;
-  for (size_t i = 0; i < sequence.size(); i++) {
+  std::size_t raw_index = 0;
+  for (std::size_t i = 0; i < sequence.size(); i++) {
     auto p = sequence[i];
     if (p < dictionary.size()) {
       for (auto it = dictionary.begin(); it != dictionary.end(); ++it) {
@@ -175,7 +175,7 @@ auto IMTF(const std::pair<std::vector<unsigned_integer_t>,
 
 /// \fn IMTF(const std::vector<unsigned_integer_t>& sequence,
 ///          const std::vector<T>& raw,
-///          size_t dictionary_max_size)
+///          std::size_t dictionary_max_size)
 /// \brief Original Inverse Move-to-Front Function
 /// \param[in] sequence MTF-ed sequence
 /// \param[in] raw Dictionary
@@ -184,11 +184,11 @@ auto IMTF(const std::pair<std::vector<unsigned_integer_t>,
 template <typename T>
 auto IMTF(const std::vector<unsigned_integer_t>& sequence,
           const std::vector<T>& raw,
-          size_t dictionary_max_size) {
+          std::size_t dictionary_max_size) {
   std::list<T> dictionary{};
   std::vector<T> ret{};
-  size_t raw_index = 0;
-  for (size_t i = 0; i < sequence.size(); i++) {
+  std::size_t raw_index = 0;
+  for (std::size_t i = 0; i < sequence.size(); i++) {
     auto p = sequence[i];
     if (p < dictionary.size()) {
       for (auto it = dictionary.begin(); it != dictionary.end(); ++it) {
@@ -216,7 +216,7 @@ auto IMTF(const std::vector<unsigned_integer_t>& sequence,
 
 /// \fn IMTF(const std::pair<std::vector<unsigned_integer_t>, std::vector<T>>&
 ///          pair,
-///          size_t dictionary_max_size)
+///          std::size_t dictionary_max_size)
 /// \brief Original Inverse Move-to-Front Function
 /// \param[in] pair std::pair of sequence MTF-ed sequence and dictionary
 /// \param[in] dictionary_max_size maximum size of the dictionary
@@ -224,7 +224,7 @@ auto IMTF(const std::vector<unsigned_integer_t>& sequence,
 template <typename T>
 auto IMTF(const std::pair<std::vector<unsigned_integer_t>,
                           std::vector<T>>& pair,
-          size_t dictionary_max_size) {
+          std::size_t dictionary_max_size) {
   return IMTF(pair.first, pair.second, dictionary_max_size);
 }
 
@@ -237,7 +237,7 @@ auto NumericIMTF(const std::vector<unsigned_integer_t>& sequence) {
   std::list<T> dictionary{};
   std::vector<T> ret{};
 
-  for (size_t i = 0; i < sequence.size(); i++) {
+  for (std::size_t i = 0; i < sequence.size(); i++) {
     auto p = T(sequence[i]);
     if (p < T(dictionary.size())) {
       for (auto&& it = dictionary.begin(); it != dictionary.end(); ++it) {

--- a/includes/prediction-by-partial-matching.h
+++ b/includes/prediction-by-partial-matching.h
@@ -6,11 +6,10 @@
 #ifndef INCLUDES_PREDICTION_BY_PARTIAL_MATCHING_H_
 #define INCLUDES_PREDICTION_BY_PARTIAL_MATCHING_H_
 
-#include <stdint.h>
-
 /// \privatesection
 int gets();
 /// \publicsection
+#include <cstdint>
 #include <vector>
 #include <map>
 #include <set>
@@ -1705,7 +1704,7 @@ class Predictor<T, Depth, MethodD> {
 /// \brief PPM Algorithm Encode Function
 /// \param[in] data sequence
 /// \param[in] A data set
-/// \return encoded sequence as \c std::vector<uint8_t>
+/// \return encoded sequence as \c std::vector<std::uint8_t>
 template <enum Method M, int Depth, typename T>
 auto Encode(const std::vector<T>& data, const std::set<T>& A) {
   Predictor<T, Depth, M> predictor(A);
@@ -1732,7 +1731,7 @@ auto Encode(const std::vector<T>& data, const std::set<T>& A) {
 /// \fn Encode(const std::vector<T>& data)
 /// \brief PPM Algorithm Encode Function
 /// \param[in] data sequence
-/// \return \c std::pair of encoded sequence as \c std::vector<uint8_t> and
+/// \return \c std::pair of encoded sequence as \c std::vector<std::uint8_t> and
 ///         \c std::pair of data set and length of the original sequence
 template <enum Method M, int Depth, typename T>
 auto Encode(const std::vector<T>& data) {
@@ -1749,7 +1748,7 @@ auto Encode(const std::vector<T>& data) {
 ///        Assumes data sequence are in [0, max].
 /// \param[in] data sequence
 /// \param[in] max minimum of supremum or maximum value of the sequence
-/// \return \c std::pair of encoded sequence as \c std::vector<uint8_t> and
+/// \return \c std::pair of encoded sequence as \c std::vector<std::uint8_t> and
 ///         length of the original sequence
 template <enum Method M, int Depth, typename T>
 auto NumericEncode(const std::vector<T>& data, const T& max) {
@@ -1764,7 +1763,7 @@ auto NumericEncode(const std::vector<T>& data, const T& max) {
 /// \brief PPM Algorithm Encode Function.
 ///        Assumes data sequence has maximum value.
 /// \param[in] data sequence
-/// \return \c std::pair of encoded sequence as \c std::vector<uint8_t> and
+/// \return \c std::pair of encoded sequence as \c std::vector<std::uint8_t> and
 ///         \c std::pair of maximum value and length of the original sequence
 template <enum Method M, int Depth, typename T>
 auto NumericEncode(const std::vector<T>& data) {
@@ -1778,7 +1777,7 @@ auto NumericEncode(const std::vector<T>& data) {
   return std::make_pair(encoded.first, std::make_pair(max, data.size()));
 }
 
-/// \fn Decode(const std::vector<uint8_t>& data,
+/// \fn Decode(const std::vector<std::uint8_t>& data,
 ///            const std::set<T>& A,
 ///            std::size_t original_size)
 /// \brief PPM Algorithm Decode Function
@@ -1787,7 +1786,7 @@ auto NumericEncode(const std::vector<T>& data) {
 /// \param[in] original_size length of the original sequence
 /// \return data sequence as \c std::vector<T>
 template <enum Method M, int Depth, typename T>
-auto Decode(const std::vector<uint8_t>& data,
+auto Decode(const std::vector<std::uint8_t>& data,
             const std::set<T>& A,
             std::size_t original_size) {
   Predictor<T, Depth, M> predictor(A);
@@ -1818,22 +1817,22 @@ auto Decode(const std::vector<uint8_t>& data,
   return ret;
 }
 
-/// \fn Decode(const std::pair<std::vector<uint8_t>,
+/// \fn Decode(const std::pair<std::vector<std::uint8_t>,
 ///                  std::pair<std::set<T>, std::size_t>>& tuple)
 /// \brief PPM Algorithm Decode Function
-/// \param[in] tuple \c std::pair of data sequence as \c std::vector<uint8_t>
+/// \param[in] tuple \c std::pair of data sequence as \c std::vector<std::uint8_t>
 ///            and \c std::pair of data set as \c std::set<T> and
 ///            length of the original sequence
 /// \return data sequence as \c std::vector<T>
 template <enum Method M, int Depth, typename T>
-auto Decode(const std::pair<std::vector<uint8_t>,
+auto Decode(const std::pair<std::vector<std::uint8_t>,
                   std::pair<std::set<T>, std::size_t>>& tuple) {
   return Decode<M, Depth, T>(tuple.first,
                              tuple.second.first,
                              tuple.second.second);
 }
 
-/// \fn NumericDecode(const std::vector<uint8_t>& data,
+/// \fn NumericDecode(const std::vector<std::uint8_t>& data,
 ///                   const T& max,
 ///                   std::size_t original_size)
 /// \brief PPM Algorithm Decode Function
@@ -1842,7 +1841,7 @@ auto Decode(const std::pair<std::vector<uint8_t>,
 /// \param[in] original_size length of the original sequence
 /// \return data sequence as \c std::vector<T>
 template <enum Method M, int Depth, typename T>
-auto NumericDecode(const std::vector<uint8_t>& data,
+auto NumericDecode(const std::vector<std::uint8_t>& data,
                    const T& max,
                    std::size_t original_size) {
   std::set<T> A{};
@@ -1852,7 +1851,7 @@ auto NumericDecode(const std::vector<uint8_t>& data,
   return Decode<M, Depth, T>(data, A, original_size);
 }
 
-/// \fn NumericDecode(const std::pair<std::vector<uint8_t>, std::size_t>& pair,
+/// \fn NumericDecode(const std::pair<std::vector<std::uint8_t>, std::size_t>& pair,
 ///                   const T& max)
 /// \brief PPM Algorithm Decode Function
 /// \param[in] pair \c std::pair of data sequence and length of the original
@@ -1861,12 +1860,12 @@ auto NumericDecode(const std::vector<uint8_t>& data,
 ///            sequence
 /// \return data sequence as \c std::vector<T>
 template <enum Method M, int Depth, typename T>
-auto NumericDecode(const std::pair<std::vector<uint8_t>, std::size_t>& pair,
+auto NumericDecode(const std::pair<std::vector<std::uint8_t>, std::size_t>& pair,
                    const T& max) {
   return NumericDecode(pair.first, max, pair.second);
 }
 
-/// \fn NumericDecode(const std::pair<std::vector<uint8_t>,
+/// \fn NumericDecode(const std::pair<std::vector<std::uint8_t>,
 ///                         std::pair<T, std::size_t>>& tuple)
 /// \brief PPM Algorithm Decode Function
 /// \param[in] tuple \c std::pair of data sequence and
@@ -1874,7 +1873,7 @@ auto NumericDecode(const std::pair<std::vector<uint8_t>, std::size_t>& pair,
 ///            original sequence and length of the original sequence
 /// \return data sequence as \c std::vector<T>
 template <enum Method M, int Depth, typename T>
-auto NumericDecode(const std::pair<std::vector<uint8_t>,
+auto NumericDecode(const std::pair<std::vector<std::uint8_t>,
                          std::pair<T, std::size_t>>& tuple) {
   return NumericDecode(tuple.first, tuple.second.first, tuple.second.second);
 }

--- a/includes/prediction-by-partial-matching.h
+++ b/includes/prediction-by-partial-matching.h
@@ -49,7 +49,7 @@ class Predictor<T, 0, MethodA> {
  private:
   std::map<T, unsigned_integer_t> freq;
   const std::set<T> A;
-  size_t n;
+  std::size_t n;
   bool escaping;
   // | <- detected -> | <- not detected -> |
   // | <-    n     -> | <-      1       -> |
@@ -216,7 +216,7 @@ class Predictor<T, Depth, MethodA> {
   std::map<std::list<T>, std::map<T, unsigned_integer_t>> freq;
   std::list<T> predecessor_list;
   const std::set<T> A;
-  std::map<std::list<T>, size_t> n;
+  std::map<std::list<T>, std::size_t> n;
   bool escaping;
 
  public:
@@ -427,7 +427,7 @@ class Predictor<T, 0, MethodB> {
   std::map<T, unsigned_integer_t> freq;
   std::set<T> once;
   const std::set<T> A;
-  size_t n;
+  std::size_t n;
   bool escaping, escaping2;
   // | <- detected -> | <- not detected -> |
   // |   | <- once -> |                    |
@@ -647,7 +647,7 @@ class Predictor<T, Depth, MethodB> {
   std::map<std::list<T>, std::set<T>> once;
   std::list<T> predecessor_list;
   const std::set<T> A;
-  std::map<std::list<T>, size_t> n;
+  std::map<std::list<T>, std::size_t> n;
   bool escaping, escaping2;
 
  public:
@@ -733,7 +733,7 @@ class Predictor<T, Depth, MethodB> {
         if (predecessor_list.size() < Depth) {
           return 1;
         }
-        size_t s1 = 0, s2 = 0;
+        std::size_t s1 = 0, s2 = 0;
         auto it = freq.find(predecessor_list);
         if (it != freq.end()) {
           s1 = it->second.size();
@@ -944,7 +944,7 @@ class Predictor<T, 0, MethodC> {
  private:
   std::map<T, unsigned_integer_t> freq;
   const std::set<T> A;
-  size_t n;
+  std::size_t n;
   bool escaping;
   // | <- detected -> | <- not detected -> |
   // | <-    n     -> | <-      u       -> |
@@ -1115,7 +1115,7 @@ class Predictor<T, Depth, MethodC> {
   std::map<std::list<T>, std::map<T, unsigned_integer_t>> freq;
   std::list<T> predecessor_list;
   const std::set<T> A;
-  std::map<std::list<T>, size_t> n;
+  std::map<std::list<T>, std::size_t> n;
   bool escaping;
 
  public:
@@ -1326,7 +1326,7 @@ class Predictor<T, 0, MethodD> {
  private:
   std::map<T, unsigned_integer_t> freq;
   const std::set<T> A;
-  size_t n;
+  std::size_t n;
   bool escaping;
   // | <- detected  -> | <- not detected -> |
   // | <- 2 * n - u -> | <-      u       -> |
@@ -1497,7 +1497,7 @@ class Predictor<T, Depth, MethodD> {
   std::map<std::list<T>, std::map<T, unsigned_integer_t>> freq;
   std::list<T> predecessor_list;
   const std::set<T> A;
-  std::map<std::list<T>, size_t> n;
+  std::map<std::list<T>, std::size_t> n;
   bool escaping;
 
  public:
@@ -1710,7 +1710,7 @@ template <enum Method M, int Depth, typename T>
 auto Encode(const std::vector<T>& data, const std::set<T>& A) {
   Predictor<T, Depth, M> predictor(A);
   auto cont = RangeCoder::encode_init<unsigned_integer_size>();
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     while (predictor.has_to_escape(data[i])) {
       auto n = predictor.numerator();
       auto d = predictor.denominator();
@@ -1737,7 +1737,7 @@ auto Encode(const std::vector<T>& data, const std::set<T>& A) {
 template <enum Method M, int Depth, typename T>
 auto Encode(const std::vector<T>& data) {
   std::set<T> set{};
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     set.insert(data[i]);
   }
   return std::make_pair(Encode<M, Depth, T>(data, set),
@@ -1769,7 +1769,7 @@ auto NumericEncode(const std::vector<T>& data, const T& max) {
 template <enum Method M, int Depth, typename T>
 auto NumericEncode(const std::vector<T>& data) {
   T max = data[0];
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     if (max < data[i]) {
       max = data[i];
     }
@@ -1780,7 +1780,7 @@ auto NumericEncode(const std::vector<T>& data) {
 
 /// \fn Decode(const std::vector<uint8_t>& data,
 ///            const std::set<T>& A,
-///            size_t original_size)
+///            std::size_t original_size)
 /// \brief PPM Algorithm Decode Function
 /// \param[in] data sequence
 /// \param[in] A data set
@@ -1789,11 +1789,11 @@ auto NumericEncode(const std::vector<T>& data) {
 template <enum Method M, int Depth, typename T>
 auto Decode(const std::vector<uint8_t>& data,
             const std::set<T>& A,
-            size_t original_size) {
+            std::size_t original_size) {
   Predictor<T, Depth, M> predictor(A);
   std::vector<T> ret{};
   auto cont = RangeCoder::decode_init<unsigned_integer_size, T>(data);
-  for (size_t i = 0; i < original_size; i++) {
+  for (std::size_t i = 0; i < original_size; i++) {
     while (RangeCoder::decode_split(cont,
                                     predictor.numerator(),
                                     predictor.denominator())) {
@@ -1819,7 +1819,7 @@ auto Decode(const std::vector<uint8_t>& data,
 }
 
 /// \fn Decode(const std::pair<std::vector<uint8_t>,
-///                  std::pair<std::set<T>, size_t>>& tuple)
+///                  std::pair<std::set<T>, std::size_t>>& tuple)
 /// \brief PPM Algorithm Decode Function
 /// \param[in] tuple \c std::pair of data sequence as \c std::vector<uint8_t>
 ///            and \c std::pair of data set as \c std::set<T> and
@@ -1827,7 +1827,7 @@ auto Decode(const std::vector<uint8_t>& data,
 /// \return data sequence as \c std::vector<T>
 template <enum Method M, int Depth, typename T>
 auto Decode(const std::pair<std::vector<uint8_t>,
-                  std::pair<std::set<T>, size_t>>& tuple) {
+                  std::pair<std::set<T>, std::size_t>>& tuple) {
   return Decode<M, Depth, T>(tuple.first,
                              tuple.second.first,
                              tuple.second.second);
@@ -1835,7 +1835,7 @@ auto Decode(const std::pair<std::vector<uint8_t>,
 
 /// \fn NumericDecode(const std::vector<uint8_t>& data,
 ///                   const T& max,
-///                   size_t original_size)
+///                   std::size_t original_size)
 /// \brief PPM Algorithm Decode Function
 /// \param[in] data sequence
 /// \param[in] max minimum of supremum or maximum value of the original sequence
@@ -1844,7 +1844,7 @@ auto Decode(const std::pair<std::vector<uint8_t>,
 template <enum Method M, int Depth, typename T>
 auto NumericDecode(const std::vector<uint8_t>& data,
                    const T& max,
-                   size_t original_size) {
+                   std::size_t original_size) {
   std::set<T> A{};
   for (T i{}; i <= max; ++i) {
     A.insert(i);
@@ -1852,7 +1852,7 @@ auto NumericDecode(const std::vector<uint8_t>& data,
   return Decode<M, Depth, T>(data, A, original_size);
 }
 
-/// \fn NumericDecode(const std::pair<std::vector<uint8_t>, size_t>& pair,
+/// \fn NumericDecode(const std::pair<std::vector<uint8_t>, std::size_t>& pair,
 ///                   const T& max)
 /// \brief PPM Algorithm Decode Function
 /// \param[in] pair \c std::pair of data sequence and length of the original
@@ -1861,13 +1861,13 @@ auto NumericDecode(const std::vector<uint8_t>& data,
 ///            sequence
 /// \return data sequence as \c std::vector<T>
 template <enum Method M, int Depth, typename T>
-auto NumericDecode(const std::pair<std::vector<uint8_t>, size_t>& pair,
+auto NumericDecode(const std::pair<std::vector<uint8_t>, std::size_t>& pair,
                    const T& max) {
   return NumericDecode(pair.first, max, pair.second);
 }
 
 /// \fn NumericDecode(const std::pair<std::vector<uint8_t>,
-///                         std::pair<T, size_t>>& tuple)
+///                         std::pair<T, std::size_t>>& tuple)
 /// \brief PPM Algorithm Decode Function
 /// \param[in] tuple \c std::pair of data sequence and
 ///            \c std::pair of minimum of supremum or maximum value of the
@@ -1875,7 +1875,7 @@ auto NumericDecode(const std::pair<std::vector<uint8_t>, size_t>& pair,
 /// \return data sequence as \c std::vector<T>
 template <enum Method M, int Depth, typename T>
 auto NumericDecode(const std::pair<std::vector<uint8_t>,
-                         std::pair<T, size_t>>& tuple) {
+                         std::pair<T, std::size_t>>& tuple) {
   return NumericDecode(tuple.first, tuple.second.first, tuple.second.second);
 }
 

--- a/includes/range-coder.h
+++ b/includes/range-coder.h
@@ -27,7 +27,7 @@ namespace ResearchLibrary {
 namespace RangeCoder {
 
 /// \privatesection
-template <size_t N>
+template <std::size_t N>
 auto mulhi(size_type_t<N> u, size_type_t<N> v) {
   return size_type_t<N>((size_type_t<2 * N>(u) * size_type_t<2 * N>(v)) >> N);
 }
@@ -43,7 +43,7 @@ auto mulhi<8>(size_type_t<8> u, size_type_t<8> v) {
   return u1 * v1 + w2 + (w1 >> 32);
 }
 
-template <size_t N>
+template <std::size_t N>
 auto idiv(size_type_t<N> x, size_type_t<N> z) {
   return size_type_t<N>((size_type_t<2 * N>(x) << N) / z);
 }
@@ -66,20 +66,20 @@ auto idiv<8>(size_type_t<8> x, size_type_t<8> z) {
   return y;
 }
 
-template <size_t N>
+template <std::size_t N>
 struct EncoderContinuation {
   std::vector<uint8_t> buffer;
   size_type_t<N> low, range;
 };
 
-template <size_t N>
+template <std::size_t N>
 auto encode_init() {
   EncoderContinuation<N> cont{};
   cont.range--;
   return cont;
 }
 
-template <size_t N>
+template <std::size_t N>
 auto encode_process(EncoderContinuation<N>&& cont,
                     size_type_t<N> low,
                     size_type_t<N> range) {
@@ -101,7 +101,7 @@ auto encode_process(EncoderContinuation<N>&& cont,
   return std::move(cont);
 }
 
-template <size_t N>
+template <std::size_t N>
 auto encode_process(EncoderContinuation<N>&& cont,
                     const size_type_t<N>& low,
                     const size_type_t<N>& range,
@@ -111,7 +111,7 @@ auto encode_process(EncoderContinuation<N>&& cont,
   return encode_process(std::move(cont), fixed_low, fixed_range);
 }
 
-template <size_t N>
+template <std::size_t N>
 auto encode_finish(EncoderContinuation<N>&& cont) {
   auto new_low = cont.low + cont.range / 2;
   if (new_low < cont.low) {
@@ -126,17 +126,17 @@ auto encode_finish(EncoderContinuation<N>&& cont) {
   return std::move(cont.buffer);
 }
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 struct DecoderContinuation {
   size_type_t<N> low, range, data, index;
   T buffer;
 };
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 auto decode_init(const std::vector<uint8_t>& data) {
   DecoderContinuation<N, T> cont{};
   cont.range = size_type_t<N>(UINT64_MAX);
-  for (size_t i = 0; i < N; i++) {
+  for (std::size_t i = 0; i < N; i++) {
     if (i < data.size()) {
       cont.data = (cont.data << 8) + data[i];
     } else {
@@ -148,10 +148,10 @@ auto decode_init(const std::vector<uint8_t>& data) {
 }
 
 // adaptive frequency
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 auto decode_split(const DecoderContinuation<N, T>& cont,
-                  size_t border,
-                  size_t sum) {
+                  std::size_t border,
+                  std::size_t sum) {
   if (border == sum) {
     return false;
   }
@@ -164,17 +164,17 @@ auto decode_split(const DecoderContinuation<N, T>& cont,
   }
 }
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 auto decode_partial_fetch(const DecoderContinuation<N, T>& cont,
                           const std::vector<unsigned_integer_t>& freq,
-                          size_t total_freq,
-                          size_t sum) {
+                          std::size_t total_freq,
+                          std::size_t sum) {
   auto ch_in_exact = idiv<N>(cont.data - cont.low, cont.range);
   auto ch_in = mulhi<N>(ch_in_exact, sum);
   if (idiv<N>(total_freq, sum) <= ch_in_exact) {
     return std::make_pair(T(0), false);
   }
-  size_t ch = 0, sum_freq = freq[0];
+  std::size_t ch = 0, sum_freq = freq[0];
   while (sum_freq <= ch_in) {
     ch++;
     sum_freq += freq[ch];
@@ -182,12 +182,12 @@ auto decode_partial_fetch(const DecoderContinuation<N, T>& cont,
   return std::make_pair(T(ch), true);
 }
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 auto decode_fetch(const DecoderContinuation<N, T>& cont,
                   const std::vector<unsigned_integer_t>& freq,
-                  size_t sum) {
+                  std::size_t sum) {
   auto ch_in = mulhi<N>(idiv<N>(cont.data - cont.low, cont.range), sum);
-  size_t ch = 0, sum_freq = freq[0];
+  std::size_t ch = 0, sum_freq = freq[0];
   while (sum_freq <= ch_in) {
     ch++;
     sum_freq += freq[ch];
@@ -195,17 +195,17 @@ auto decode_fetch(const DecoderContinuation<N, T>& cont,
   return T(ch);
 }
 
-template <size_t N, typename T>
-auto decode_fetch(const DecoderContinuation<N, T>& cont, size_t sum) {
+template <std::size_t N, typename T>
+auto decode_fetch(const DecoderContinuation<N, T>& cont, std::size_t sum) {
   return mulhi<N>(idiv<N>(cont.data - cont.low, cont.range), sum);
 }
 
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 auto decode_process(DecoderContinuation<N, T>&& cont,
                     const std::vector<uint8_t>& data,
                     const unsigned_integer_t low,
                     const unsigned_integer_t range,
-                    size_t sum) {
+                    std::size_t sum) {
   auto fixed_low = idiv<N>(low, sum);
   auto fixed_range = idiv<N>(range, sum);
   auto new_low = cont.low + mulhi<N>(cont.range, fixed_low);
@@ -225,14 +225,14 @@ auto decode_process(DecoderContinuation<N, T>&& cont,
 }
 
 // fixed frequency
-template <size_t N, typename T>
+template <std::size_t N, typename T>
 auto decode_process(DecoderContinuation<N, T>&& cont,
                     const std::vector<uint8_t>& data,
                     const std::vector<std::pair<T, unsigned_integer_t>>& freq,
                     const std::vector<unsigned_integer_t>& sum_freq) {
   auto sum = sum_freq.back() + freq.back().second;
   auto ch_in = mulhi<N>(idiv<N>(cont.data - cont.low, cont.range), sum);
-  size_t left = 0, right = freq.size() - 1;
+  std::size_t left = 0, right = freq.size() - 1;
   while (left < right) {
     auto mid = (left + right) / 2;
     if (sum_freq[mid + 1] <= ch_in) {
@@ -279,7 +279,7 @@ auto StaticEncode(const std::vector<T>& data,
     sum += it->second;
   }
   auto&& cont = encode_init<unsigned_integer_size>();
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     cont = encode_process(std::move(cont),
                           sum_freq[data[i]],
                           freq_map[data[i]],
@@ -312,7 +312,7 @@ auto StaticEncode(const std::vector<T>& data) {
 
 /// \fn StaticDecode(const std::vector<uint8_t>& data,
 ///                  const std::vector<std::pair<T, unsigned_integer_t>>& freq,
-///                  size_t original_size)
+///                  std::size_t original_size)
 /// \brief RangeCoder Static Decode Function
 /// \param[in] data sequence
 /// \param[in] freq list of frequency of the characters on the source
@@ -321,7 +321,7 @@ auto StaticEncode(const std::vector<T>& data) {
 template <typename T>
 auto StaticDecode(const std::vector<uint8_t>& data,
                   const std::vector<std::pair<T, unsigned_integer_t>>& freq,
-                  size_t original_size) {
+                  std::size_t original_size) {
   std::vector<unsigned_integer_t> sum_freq;
   unsigned_integer_t sum = 0;
   for (auto&& it = freq.begin(); it != freq.end(); ++it) {
@@ -330,7 +330,7 @@ auto StaticDecode(const std::vector<uint8_t>& data,
   }
   std::vector<T> ret;
   auto&& cont = decode_init<unsigned_integer_size, T>(data);
-  for (size_t i = 0; i < original_size; i++) {
+  for (std::size_t i = 0; i < original_size; i++) {
     cont = decode_process(std::move(cont), data, freq, sum_freq);
     ret.push_back(cont.buffer);
   }
@@ -341,19 +341,19 @@ auto StaticDecode(const std::vector<uint8_t>& data,
 ///       const std::pair<std::vector<uint8_t>,
 ///                       std::pair<std::vector<std::pair<T,
 ///                                                       unsigned_integer_t>>,
-///                                 size_t>>& tuple)
+///                                 std::size_t>>& tuple)
 /// \brief RangeCoder Static Decode Function
 /// \param[in] tuple std::pair of data sequence as std::vector<uint8_t> and
 ///            std::pair of list of frequency of the characters on the source as
 ///            std::vector<std::pair<T, unsigned_integer_t>> and data length as
-///            size_t
+///            std::size_t
 /// \return original sequence as std::vector<T>
 template <typename T>
 auto StaticDecode(const std::pair<
                           std::vector<uint8_t>,
                           std::pair<
                             std::vector<std::pair<T, unsigned_integer_t>>,
-                            size_t>>& tuple) {
+                            std::size_t>>& tuple) {
   return StaticDecode(tuple.first, tuple.second.first, tuple.second.second);
 }
 
@@ -363,22 +363,22 @@ auto StaticDecode(const std::pair<
 /// \param[in] data sequence
 /// \param[in] max maximum value of the data
 /// \return \c std::pair of sequence as \c std::vector<uint8_t> and
-///         length of the data sequence as \c size_t
+///         length of the data sequence as \c std::size_t
 template <typename T>
 auto AdaptiveEncodeA(const std::vector<T>& data, const T& max) {
-  auto A = size_t(max + 1);
+  auto A = std::size_t(max + 1);
   std::vector<unsigned_integer_t> sum_freq(A, 0), freq(A, 0);
   std::vector<unsigned_integer_t> sum_nfreq(A, 0), nfreq(A, 1);
   unsigned_integer_t sum = 0;
-  for (size_t i = 0; i < sum_nfreq.size(); i++) {
+  for (std::size_t i = 0; i < sum_nfreq.size(); i++) {
     sum_nfreq[i] = sum;
     sum += nfreq[i];
   }
-  size_t incorrect_sum_freq_min = 0, u = 0;
+  std::size_t incorrect_sum_freq_min = 0, u = 0;
   auto&& cont = encode_init<unsigned_integer_size>();
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     auto n = i + 1;
-    auto d = size_t(data[i]);
+    auto d = std::size_t(data[i]);
     if (freq[d] == 0) {
       cont = encode_process(std::move(cont), i, 1, n);
       cont = encode_process(std::move(cont), sum_nfreq[d], 1, A - u);
@@ -412,12 +412,12 @@ auto AdaptiveEncodeA(const std::vector<T>& data, const T& max) {
 ///        To solve the zero-frequency-problem, use the Method A.
 /// \param[in] data sequence
 /// \return \c std::pair of sequence as \c std::vector<uint8_t> and
-///         \c std::pair of length of the original sequence as \c size_t and
+///         \c std::pair of length of the original sequence as \c std::size_t and
 ///         maximum value of the original sequence as \c T
 template <typename T>
 auto AdaptiveEncodeA(const std::vector<T>& data) {
   T max{};
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     if (max < data[i]) {
       max = data[i];
     }
@@ -429,7 +429,7 @@ auto AdaptiveEncodeA(const std::vector<T>& data) {
 }
 
 /// \fn AdaptiveDecodeA(const std::vector<uint8_t>& data,
-///                    size_t original_size,
+///                    std::size_t original_size,
 ///                    const T& max)
 /// \brief RangeCoder Adaptive Decode Function.
 ///        To solve the zero-frequency-problem, use the Method A.
@@ -439,27 +439,27 @@ auto AdaptiveEncodeA(const std::vector<T>& data) {
 /// \return original sequence as \c std::vector<T>
 template <typename T>
 auto AdaptiveDecodeA(const std::vector<uint8_t>& data,
-                     size_t original_size,
+                     std::size_t original_size,
                      const T& max) {
-  auto A = size_t(max + 1);
+  auto A = std::size_t(max + 1);
   std::vector<unsigned_integer_t> sum_freq(A, 0), freq(A, 0);
   std::vector<unsigned_integer_t> sum_nfreq(A, 0), nfreq(A, 1);
   unsigned_integer_t sum = 0;
-  for (size_t i = 0; i < sum_nfreq.size(); i++) {
+  for (std::size_t i = 0; i < sum_nfreq.size(); i++) {
     sum_nfreq[i] = sum;
     sum += nfreq[i];
   }
-  size_t incorrect_sum_freq_min = 0, u = 0;
+  std::size_t incorrect_sum_freq_min = 0, u = 0;
   std::vector<T> ret;
   auto&& cont = decode_init<unsigned_integer_size, T>(data);
-  for (size_t i = 0; i < original_size; i++) {
+  for (std::size_t i = 0; i < original_size; i++) {
     auto n = i + 1;
     auto decode = decode_partial_fetch(cont, freq, i, n);
-    auto d = size_t(decode.first);
+    auto d = std::size_t(decode.first);
     if (!decode.second) {
       cont = decode_process(std::move(cont), data, i, 1, n);
       auto Td = decode_fetch(cont, nfreq, A - u);
-      d = size_t(Td);
+      d = std::size_t(Td);
       cont = decode_process(std::move(cont), data, sum_nfreq[d], 1, A - u);
       nfreq[d] = 0;
       for (auto j = d + 1; j < sum_nfreq.size(); j++) {
@@ -490,16 +490,16 @@ auto AdaptiveDecodeA(const std::vector<uint8_t>& data,
 
 /// \fn AdaptiveDecodeA(const std::pair<
 ///                            std::vector<uint8_t>,
-///                            std::pair<size_t, T>>& pair)
+///                            std::pair<std::size_t, T>>& pair)
 /// \brief RangeCoder Adaptive Decode Function.
 ///        To solve the zero-frequency-problem, use the Method A.
 /// \param[in] pair \c std::pair of sequence as std::vector<uint8_t> and
-///            \c std::pair of length of the original sequence as \c size_t and
+///            \c std::pair of length of the original sequence as \c std::size_t and
 ///            maximum value of the original sequence
 /// \return original sequence as \c std::vector<T>
 template <typename T>
 auto AdaptiveDecodeA(const std::pair<std::vector<uint8_t>,
-                           std::pair<size_t, T>>& tuple) {
+                           std::pair<std::size_t, T>>& tuple) {
   return AdaptiveDecodeA(tuple.first, tuple.second.first, tuple.second.second);
 }
 
@@ -509,22 +509,22 @@ auto AdaptiveDecodeA(const std::pair<std::vector<uint8_t>,
 /// \param[in] data sequence
 /// \param[in] max maximum value of the data
 /// \return \c std::pair of sequence as \c std::vector<uint8_t> and
-///         length of the data sequence as \c size_t
+///         length of the data sequence as \c std::size_t
 template <typename T>
 auto AdaptiveEncodeB(const std::vector<T>& data, const T& max) {
-  auto A = size_t(max + 1);
+  auto A = std::size_t(max + 1);
   std::vector<unsigned_integer_t> sum_freq(A, 0), freq(A, 0), freqm1(A, 0);
   std::vector<unsigned_integer_t> sum_nfreq(A, 0), nfreq(A, 1);
   std::vector<unsigned_integer_t> sum_nfreq2(A, 0), nfreq2(A, 0);
   unsigned_integer_t sum = 0;
-  for (size_t i = 0; i < sum_nfreq.size(); i++) {
+  for (std::size_t i = 0; i < sum_nfreq.size(); i++) {
     sum_nfreq[i] = sum;
     sum += nfreq[i];
   }
-  size_t incorrect_sum_freq_min = 0, u = 0, v = 0;
+  std::size_t incorrect_sum_freq_min = 0, u = 0, v = 0;
   auto&& cont = encode_init<unsigned_integer_size>();
-  for (size_t i = 0; i < data.size(); i++) {
-    auto d = size_t(data[i]);
+  for (std::size_t i = 0; i < data.size(); i++) {
+    auto d = std::size_t(data[i]);
     if (freq[d] <= 1) {
       if (i != 0) {
         cont = encode_process(std::move(cont), i - u, u, i);
@@ -575,12 +575,12 @@ auto AdaptiveEncodeB(const std::vector<T>& data, const T& max) {
 ///        To solve the zero-frequency-problem, use the Method B.
 /// \param[in] data sequence
 /// \return \c std::pair of sequence as \c std::vector<uint8_t> and
-///         \c std::pair of length of the original sequence as \c size_t and
+///         \c std::pair of length of the original sequence as \c std::size_t and
 ///         maximum value of the original sequence as \c T
 template <typename T>
 auto AdaptiveEncodeB(const std::vector<T>& data) {
   T max{};
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     if (max < data[i]) {
       max = data[i];
     }
@@ -592,7 +592,7 @@ auto AdaptiveEncodeB(const std::vector<T>& data) {
 }
 
 /// \fn AdaptiveDecodeB(const std::vector<uint8_t>& data,
-///                    size_t original_size,
+///                    std::size_t original_size,
 ///                    const T& max)
 /// \brief RangeCoder Adaptive Decode Function.
 ///        To solve the zero-frequency-problem, use the Method B.
@@ -602,30 +602,30 @@ auto AdaptiveEncodeB(const std::vector<T>& data) {
 /// \return original sequence as \c std::vector<T>
 template <typename T>
 auto AdaptiveDecodeB(const std::vector<uint8_t>& data,
-                     size_t original_size,
+                     std::size_t original_size,
                      const T& max) {
-  auto A = size_t(max + 1);
+  auto A = std::size_t(max + 1);
   std::vector<unsigned_integer_t> sum_freq(A, 0), freq(A, 0), freqm1(A, 0);
   std::vector<unsigned_integer_t> sum_nfreq(A, 0), nfreq(A, 1);
   std::vector<unsigned_integer_t> sum_nfreq2(A, 0), nfreq2(A, 0);
   unsigned_integer_t sum = 0;
-  for (size_t i = 0; i < sum_nfreq.size(); i++) {
+  for (std::size_t i = 0; i < sum_nfreq.size(); i++) {
     sum_nfreq[i] = sum;
     sum += nfreq[i];
   }
-  size_t incorrect_sum_freq_min = 0, u = 0, v = 0;
+  std::size_t incorrect_sum_freq_min = 0, u = 0, v = 0;
   std::vector<T> ret;
   auto&& cont = decode_init<unsigned_integer_size, T>(data);
-  for (size_t i = 0; i < original_size; i++) {
+  for (std::size_t i = 0; i < original_size; i++) {
     auto decode = decode_partial_fetch(cont, freqm1, i - u, i);
-    auto d = size_t(decode.first);
+    auto d = std::size_t(decode.first);
     if (!decode.second || i == 0) {
       if (i != 0) {
         cont = decode_process(std::move(cont), data, i - u, u, i);
       }
       auto n = A - u + v;
       decode = decode_partial_fetch(cont, nfreq, A - u, n);
-      d = size_t(decode.first);
+      d = std::size_t(decode.first);
       if (decode.second) {
         cont = decode_process(std::move(cont), data, sum_nfreq[d], 1, n);
         nfreq[d] = 0;
@@ -639,7 +639,7 @@ auto AdaptiveDecodeB(const std::vector<uint8_t>& data,
       } else {
         cont = decode_process(std::move(cont), data, A - u, v, n);
         decode.first = decode_fetch(cont, nfreq2, v);
-        d = size_t(decode.first);
+        d = std::size_t(decode.first);
         cont = decode_process(std::move(cont), data, sum_nfreq2[d], 1, v);
         nfreq2[d] = 0;
         for (auto j = d + 1; j < sum_nfreq2.size(); j++) {
@@ -671,16 +671,16 @@ auto AdaptiveDecodeB(const std::vector<uint8_t>& data,
 
 /// \fn AdaptiveDecodeB(const std::pair<
 ///                            std::vector<uint8_t>,
-///                            std::pair<size_t, T>>& pair)
+///                            std::pair<std::size_t, T>>& pair)
 /// \brief RangeCoder Adaptive Decode Function.
 ///        To solve the zero-frequency-problem, use the Method B.
 /// \param[in] pair \c std::pair of sequence as std::vector<uint8_t> and
-///            \c std::pair of length of the original sequence as \c size_t and
+///            \c std::pair of length of the original sequence as \c std::size_t and
 ///            maximum value of the original sequence
 /// \return original sequence as \c std::vector<T>
 template <typename T>
 auto AdaptiveDecodeB(const std::pair<std::vector<uint8_t>,
-                           std::pair<size_t, T>>& tuple) {
+                           std::pair<std::size_t, T>>& tuple) {
   return AdaptiveDecodeB(tuple.first, tuple.second.first, tuple.second.second);
 }
 
@@ -690,22 +690,22 @@ auto AdaptiveDecodeB(const std::pair<std::vector<uint8_t>,
 /// \param[in] data sequence
 /// \param[in] max maximum value of the data
 /// \return \c std::pair of sequence as \c std::vector<uint8_t> and
-///         length of the data sequence as \c size_t
+///         length of the data sequence as \c std::size_t
 template <typename T>
 auto AdaptiveEncodeC(const std::vector<T>& data, const T& max) {
-  auto A = size_t(max + 1);
+  auto A = std::size_t(max + 1);
   std::vector<unsigned_integer_t> sum_freq(A, 0), freq(A, 0);
   std::vector<unsigned_integer_t> sum_nfreq(A, 0), nfreq(A, 1);
   unsigned_integer_t sum = 0;
-  for (size_t i = 0; i < sum_nfreq.size(); i++) {
+  for (std::size_t i = 0; i < sum_nfreq.size(); i++) {
     sum_nfreq[i] = sum;
     sum += nfreq[i];
   }
-  size_t incorrect_sum_freq_min = 0, u = 0;
+  std::size_t incorrect_sum_freq_min = 0, u = 0;
   auto&& cont = encode_init<unsigned_integer_size>();
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     auto n = i + u;
-    auto d = size_t(data[i]);
+    auto d = std::size_t(data[i]);
     if (freq[d] == 0) {
       if (i != 0) {
         cont = encode_process(std::move(cont), i, u, n);
@@ -741,12 +741,12 @@ auto AdaptiveEncodeC(const std::vector<T>& data, const T& max) {
 ///        To solve the zero-frequency-problem, use the Method C.
 /// \param[in] data sequence
 /// \return \c std::pair of sequence as \c std::vector<uint8_t> and
-///         \c std::pair of length of the original sequence as \c size_t and
+///         \c std::pair of length of the original sequence as \c std::size_t and
 ///         maximum value of the original sequence as \c T
 template <typename T>
 auto AdaptiveEncodeC(const std::vector<T>& data) {
   T max{};
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     if (max < data[i]) {
       max = data[i];
     }
@@ -758,7 +758,7 @@ auto AdaptiveEncodeC(const std::vector<T>& data) {
 }
 
 /// \fn AdaptiveDecodeC(const std::vector<uint8_t>& data,
-///                    size_t original_size,
+///                    std::size_t original_size,
 ///                    const T& max)
 /// \brief RangeCoder Adaptive Decode Function.
 ///        To solve the zero-frequency-problem, use the Method C.
@@ -768,29 +768,29 @@ auto AdaptiveEncodeC(const std::vector<T>& data) {
 /// \return original sequence as \c std::vector<T>
 template <typename T>
 auto AdaptiveDecodeC(const std::vector<uint8_t>& data,
-                     size_t original_size,
+                     std::size_t original_size,
                      const T& max) {
-  auto A = size_t(max + 1);
+  auto A = std::size_t(max + 1);
   std::vector<unsigned_integer_t> sum_freq(A, 0), freq(A, 0);
   std::vector<unsigned_integer_t> sum_nfreq(A, 0), nfreq(A, 1);
   unsigned_integer_t sum = 0;
-  for (size_t i = 0; i < sum_nfreq.size(); i++) {
+  for (std::size_t i = 0; i < sum_nfreq.size(); i++) {
     sum_nfreq[i] = sum;
     sum += nfreq[i];
   }
-  size_t incorrect_sum_freq_min = 0, u = 0;
+  std::size_t incorrect_sum_freq_min = 0, u = 0;
   std::vector<T> ret;
   auto&& cont = decode_init<unsigned_integer_size, T>(data);
-  for (size_t i = 0; i < original_size; i++) {
+  for (std::size_t i = 0; i < original_size; i++) {
     auto n = i + u;
     auto decode = decode_partial_fetch(cont, freq, i, n);
-    auto d = size_t(decode.first);
+    auto d = std::size_t(decode.first);
     if (!decode.second || i == 0) {
       if (i != 0) {
         cont = decode_process(std::move(cont), data, i, u, n);
       }
       auto Td = decode_fetch(cont, nfreq, A - u);
-      d = size_t(Td);
+      d = std::size_t(Td);
       cont = decode_process(std::move(cont), data, sum_nfreq[d], 1, A - u);
       nfreq[d] = 0;
       for (auto j = d + 1; j < sum_nfreq.size(); j++) {
@@ -821,16 +821,16 @@ auto AdaptiveDecodeC(const std::vector<uint8_t>& data,
 
 /// \fn AdaptiveDecodeC(const std::pair<
 ///                            std::vector<uint8_t>,
-///                            std::pair<size_t, T>>& pair)
+///                            std::pair<std::size_t, T>>& pair)
 /// \brief RangeCoder Adaptive Decode Function.
 ///        To solve the zero-frequency-problem, use the Method C.
 /// \param[in] pair \c std::pair of sequence as std::vector<uint8_t> and
-///            \c std::pair of length of the original sequence as \c size_t and
+///            \c std::pair of length of the original sequence as \c std::size_t and
 ///            maximum value of the original sequence
 /// \return original sequence as \c std::vector<T>
 template <typename T>
 auto AdaptiveDecodeC(const std::pair<std::vector<uint8_t>,
-                           std::pair<size_t, T>>& tuple) {
+                           std::pair<std::size_t, T>>& tuple) {
   return AdaptiveDecodeC(tuple.first, tuple.second.first, tuple.second.second);
 }
 
@@ -840,21 +840,21 @@ auto AdaptiveDecodeC(const std::pair<std::vector<uint8_t>,
 /// \param[in] data sequence
 /// \param[in] max maximum value of the data
 /// \return \c std::pair of sequence as \c std::vector<uint8_t> and
-///         length of the data sequence as \c size_t
+///         length of the data sequence as \c std::size_t
 template <typename T>
 auto AdaptiveEncodeD(const std::vector<T>& data, const T& max) {
-  auto A = size_t(max + 1);
+  auto A = std::size_t(max + 1);
   std::vector<unsigned_integer_t> sum_freq(A, 0), freq(A, 0);
   std::vector<unsigned_integer_t> sum_nfreq(A, 0), nfreq(A, 1);
   unsigned_integer_t sum = 0;
-  for (size_t i = 0; i < sum_nfreq.size(); i++) {
+  for (std::size_t i = 0; i < sum_nfreq.size(); i++) {
     sum_nfreq[i] = sum;
     sum += nfreq[i];
   }
-  size_t incorrect_sum_freq_min = 0, u = 0;
+  std::size_t incorrect_sum_freq_min = 0, u = 0;
   auto&& cont = encode_init<unsigned_integer_size>();
-  for (size_t i = 0; i < data.size(); i++) {
-    auto d = size_t(data[i]);
+  for (std::size_t i = 0; i < data.size(); i++) {
+    auto d = std::size_t(data[i]);
     if (freq[d] == 0) {
       if (i != 0) {
         cont = encode_process(std::move(cont), i * 2 - u, u, i * 2);
@@ -891,12 +891,12 @@ auto AdaptiveEncodeD(const std::vector<T>& data, const T& max) {
 ///        To solve the zero-frequency-problem, use the Method D.
 /// \param[in] data sequence
 /// \return \c std::pair of sequence as \c std::vector<uint8_t> and
-///         \c std::pair of length of the original sequence as \c size_t and
+///         \c std::pair of length of the original sequence as \c std::size_t and
 ///         maximum value of the original sequence as \c T
 template <typename T>
 auto AdaptiveEncodeD(const std::vector<T>& data) {
   T max{};
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     if (max < data[i]) {
       max = data[i];
     }
@@ -908,7 +908,7 @@ auto AdaptiveEncodeD(const std::vector<T>& data) {
 }
 
 /// \fn AdaptiveDecodeD(const std::vector<uint8_t>& data,
-///                    size_t original_size,
+///                    std::size_t original_size,
 ///                    const T& max)
 /// \brief RangeCoder Adaptive Decode Function.
 ///        To solve the zero-frequency-problem, use the Method D.
@@ -918,28 +918,28 @@ auto AdaptiveEncodeD(const std::vector<T>& data) {
 /// \return original sequence as \c std::vector<T>
 template <typename T>
 auto AdaptiveDecodeD(const std::vector<uint8_t>& data,
-                     size_t original_size,
+                     std::size_t original_size,
                      const T& max) {
-  auto A = size_t(max + 1);
+  auto A = std::size_t(max + 1);
   std::vector<unsigned_integer_t> sum_freq(A, 0), freq(A, 0);
   std::vector<unsigned_integer_t> sum_nfreq(A, 0), nfreq(A, 1);
   unsigned_integer_t sum = 0;
-  for (size_t i = 0; i < sum_nfreq.size(); i++) {
+  for (std::size_t i = 0; i < sum_nfreq.size(); i++) {
     sum_nfreq[i] = sum;
     sum += nfreq[i];
   }
-  size_t incorrect_sum_freq_min = 0, u = 0;
+  std::size_t incorrect_sum_freq_min = 0, u = 0;
   std::vector<T> ret;
   auto&& cont = decode_init<unsigned_integer_size, T>(data);
-  for (size_t i = 0; i < original_size; i++) {
+  for (std::size_t i = 0; i < original_size; i++) {
     auto decode = decode_partial_fetch(cont, freq, i * 2 - u, i * 2);
-    auto d = size_t(decode.first);
+    auto d = std::size_t(decode.first);
     if (!decode.second || i == 0) {
       if (i != 0) {
         cont = decode_process(std::move(cont), data, i * 2 - u, u, i * 2);
       }
       auto Td = decode_fetch(cont, nfreq, A - u);
-      d = size_t(Td);
+      d = std::size_t(Td);
       cont = decode_process(std::move(cont), data, sum_nfreq[d], 1, A - u);
       nfreq[d] = 0;
       for (auto j = d + 1; j < sum_nfreq.size(); j++) {
@@ -971,16 +971,16 @@ auto AdaptiveDecodeD(const std::vector<uint8_t>& data,
 
 /// \fn AdaptiveDecodeD(const std::pair<
 ///                            std::vector<uint8_t>,
-///                            std::pair<size_t, T>>& pair)
+///                            std::pair<std::size_t, T>>& pair)
 /// \brief RangeCoder Adaptive Decode Function.
 ///        To solve the zero-frequency-problem, use the Method D.
 /// \param[in] pair \c std::pair of sequence as std::vector<uint8_t> and
-///            \c std::pair of length of the original sequence as \c size_t and
+///            \c std::pair of length of the original sequence as \c std::size_t and
 ///            maximum value of the original sequence
 /// \return original sequence as \c std::vector<T>
 template <typename T>
 auto AdaptiveDecodeD(const std::pair<std::vector<uint8_t>,
-                           std::pair<size_t, T>>& tuple) {
+                           std::pair<std::size_t, T>>& tuple) {
   return AdaptiveDecodeD(tuple.first, tuple.second.first, tuple.second.second);
 }
 

--- a/includes/range-coder.h
+++ b/includes/range-coder.h
@@ -6,11 +6,10 @@
 #ifndef INCLUDES_RANGE_CODER_H_
 #define INCLUDES_RANGE_CODER_H_
 
-#include <stdint.h>
-
 /// \privatesection
 int gets();
 /// \publicsection
+#include <cstdint>
 #include <vector>
 #include <map>
 #include <utility>
@@ -68,7 +67,7 @@ auto idiv<8>(size_type_t<8> x, size_type_t<8> z) {
 
 template <std::size_t N>
 struct EncoderContinuation {
-  std::vector<uint8_t> buffer;
+  std::vector<std::uint8_t> buffer;
   size_type_t<N> low, range;
 };
 
@@ -133,7 +132,7 @@ struct DecoderContinuation {
 };
 
 template <std::size_t N, typename T>
-auto decode_init(const std::vector<uint8_t>& data) {
+auto decode_init(const std::vector<std::uint8_t>& data) {
   DecoderContinuation<N, T> cont{};
   cont.range = size_type_t<N>(UINT64_MAX);
   for (std::size_t i = 0; i < N; i++) {
@@ -202,7 +201,7 @@ auto decode_fetch(const DecoderContinuation<N, T>& cont, std::size_t sum) {
 
 template <std::size_t N, typename T>
 auto decode_process(DecoderContinuation<N, T>&& cont,
-                    const std::vector<uint8_t>& data,
+                    const std::vector<std::uint8_t>& data,
                     const unsigned_integer_t low,
                     const unsigned_integer_t range,
                     std::size_t sum) {
@@ -227,7 +226,7 @@ auto decode_process(DecoderContinuation<N, T>&& cont,
 // fixed frequency
 template <std::size_t N, typename T>
 auto decode_process(DecoderContinuation<N, T>&& cont,
-                    const std::vector<uint8_t>& data,
+                    const std::vector<std::uint8_t>& data,
                     const std::vector<std::pair<T, unsigned_integer_t>>& freq,
                     const std::vector<unsigned_integer_t>& sum_freq) {
   auto sum = sum_freq.back() + freq.back().second;
@@ -267,7 +266,7 @@ auto decode_process(DecoderContinuation<N, T>&& cont,
 /// \brief RangeCoder Static Encode Function
 /// \param[in] data sequence
 /// \param[in] freq list of frequency of the characters
-/// \return encoded sequence as \c std::vector<uint8_t>
+/// \return encoded sequence as \c std::vector<std::uint8_t>
 template <typename T>
 auto StaticEncode(const std::vector<T>& data,
                   const std::vector<std::pair<T, unsigned_integer_t>>& freq) {
@@ -291,7 +290,7 @@ auto StaticEncode(const std::vector<T>& data,
 /// \fn StaticEncode(const std::vector<T>& data)
 /// \brief RangeCoder Static Encode Function
 /// \param[in] data sequence
-/// \return std::pair of encoded sequence as \c std::vector<uint8_t> and
+/// \return std::pair of encoded sequence as \c std::vector<std::uint8_t> and
 ///         list of frequency of the characters as
 ///         std::vector<std::pair<T, unsigned_integer_t>>
 template <typename T>
@@ -310,7 +309,7 @@ auto StaticEncode(const std::vector<T>& data) {
                                        data.size()));
 }
 
-/// \fn StaticDecode(const std::vector<uint8_t>& data,
+/// \fn StaticDecode(const std::vector<std::uint8_t>& data,
 ///                  const std::vector<std::pair<T, unsigned_integer_t>>& freq,
 ///                  std::size_t original_size)
 /// \brief RangeCoder Static Decode Function
@@ -319,7 +318,7 @@ auto StaticEncode(const std::vector<T>& data) {
 /// \param[in] original_size length of the original sequence
 /// \return original sequence as std::vector<T>
 template <typename T>
-auto StaticDecode(const std::vector<uint8_t>& data,
+auto StaticDecode(const std::vector<std::uint8_t>& data,
                   const std::vector<std::pair<T, unsigned_integer_t>>& freq,
                   std::size_t original_size) {
   std::vector<unsigned_integer_t> sum_freq;
@@ -338,19 +337,19 @@ auto StaticDecode(const std::vector<uint8_t>& data,
 }
 
 /// \fn StaticDecode(
-///       const std::pair<std::vector<uint8_t>,
+///       const std::pair<std::vector<std::uint8_t>,
 ///                       std::pair<std::vector<std::pair<T,
 ///                                                       unsigned_integer_t>>,
 ///                                 std::size_t>>& tuple)
 /// \brief RangeCoder Static Decode Function
-/// \param[in] tuple std::pair of data sequence as std::vector<uint8_t> and
+/// \param[in] tuple std::pair of data sequence as std::vector<std::uint8_t> and
 ///            std::pair of list of frequency of the characters on the source as
 ///            std::vector<std::pair<T, unsigned_integer_t>> and data length as
 ///            std::size_t
 /// \return original sequence as std::vector<T>
 template <typename T>
 auto StaticDecode(const std::pair<
-                          std::vector<uint8_t>,
+                          std::vector<std::uint8_t>,
                           std::pair<
                             std::vector<std::pair<T, unsigned_integer_t>>,
                             std::size_t>>& tuple) {
@@ -362,7 +361,7 @@ auto StaticDecode(const std::pair<
 ///        To solve the zero-frequency-problem, use the Method A.
 /// \param[in] data sequence
 /// \param[in] max maximum value of the data
-/// \return \c std::pair of sequence as \c std::vector<uint8_t> and
+/// \return \c std::pair of sequence as \c std::vector<std::uint8_t> and
 ///         length of the data sequence as \c std::size_t
 template <typename T>
 auto AdaptiveEncodeA(const std::vector<T>& data, const T& max) {
@@ -411,7 +410,7 @@ auto AdaptiveEncodeA(const std::vector<T>& data, const T& max) {
 /// \brief RangeCoder Adaptive Encode Function.
 ///        To solve the zero-frequency-problem, use the Method A.
 /// \param[in] data sequence
-/// \return \c std::pair of sequence as \c std::vector<uint8_t> and
+/// \return \c std::pair of sequence as \c std::vector<std::uint8_t> and
 ///         \c std::pair of length of the original sequence as \c std::size_t and
 ///         maximum value of the original sequence as \c T
 template <typename T>
@@ -428,7 +427,7 @@ auto AdaptiveEncodeA(const std::vector<T>& data) {
                                        std::move(max)));
 }
 
-/// \fn AdaptiveDecodeA(const std::vector<uint8_t>& data,
+/// \fn AdaptiveDecodeA(const std::vector<std::uint8_t>& data,
 ///                    std::size_t original_size,
 ///                    const T& max)
 /// \brief RangeCoder Adaptive Decode Function.
@@ -438,7 +437,7 @@ auto AdaptiveEncodeA(const std::vector<T>& data) {
 /// \param[in] max maximum value of the original sequence
 /// \return original sequence as \c std::vector<T>
 template <typename T>
-auto AdaptiveDecodeA(const std::vector<uint8_t>& data,
+auto AdaptiveDecodeA(const std::vector<std::uint8_t>& data,
                      std::size_t original_size,
                      const T& max) {
   auto A = std::size_t(max + 1);
@@ -489,16 +488,16 @@ auto AdaptiveDecodeA(const std::vector<uint8_t>& data,
 }
 
 /// \fn AdaptiveDecodeA(const std::pair<
-///                            std::vector<uint8_t>,
+///                            std::vector<std::uint8_t>,
 ///                            std::pair<std::size_t, T>>& pair)
 /// \brief RangeCoder Adaptive Decode Function.
 ///        To solve the zero-frequency-problem, use the Method A.
-/// \param[in] pair \c std::pair of sequence as std::vector<uint8_t> and
+/// \param[in] pair \c std::pair of sequence as std::vector<std::uint8_t> and
 ///            \c std::pair of length of the original sequence as \c std::size_t and
 ///            maximum value of the original sequence
 /// \return original sequence as \c std::vector<T>
 template <typename T>
-auto AdaptiveDecodeA(const std::pair<std::vector<uint8_t>,
+auto AdaptiveDecodeA(const std::pair<std::vector<std::uint8_t>,
                            std::pair<std::size_t, T>>& tuple) {
   return AdaptiveDecodeA(tuple.first, tuple.second.first, tuple.second.second);
 }
@@ -508,7 +507,7 @@ auto AdaptiveDecodeA(const std::pair<std::vector<uint8_t>,
 ///        To solve the zero-frequency-problem, use the Method B.
 /// \param[in] data sequence
 /// \param[in] max maximum value of the data
-/// \return \c std::pair of sequence as \c std::vector<uint8_t> and
+/// \return \c std::pair of sequence as \c std::vector<std::uint8_t> and
 ///         length of the data sequence as \c std::size_t
 template <typename T>
 auto AdaptiveEncodeB(const std::vector<T>& data, const T& max) {
@@ -574,7 +573,7 @@ auto AdaptiveEncodeB(const std::vector<T>& data, const T& max) {
 /// \brief RangeCoder Adaptive Encode Function.
 ///        To solve the zero-frequency-problem, use the Method B.
 /// \param[in] data sequence
-/// \return \c std::pair of sequence as \c std::vector<uint8_t> and
+/// \return \c std::pair of sequence as \c std::vector<std::uint8_t> and
 ///         \c std::pair of length of the original sequence as \c std::size_t and
 ///         maximum value of the original sequence as \c T
 template <typename T>
@@ -591,7 +590,7 @@ auto AdaptiveEncodeB(const std::vector<T>& data) {
                                        std::move(max)));
 }
 
-/// \fn AdaptiveDecodeB(const std::vector<uint8_t>& data,
+/// \fn AdaptiveDecodeB(const std::vector<std::uint8_t>& data,
 ///                    std::size_t original_size,
 ///                    const T& max)
 /// \brief RangeCoder Adaptive Decode Function.
@@ -601,7 +600,7 @@ auto AdaptiveEncodeB(const std::vector<T>& data) {
 /// \param[in] max maximum value of the original sequence
 /// \return original sequence as \c std::vector<T>
 template <typename T>
-auto AdaptiveDecodeB(const std::vector<uint8_t>& data,
+auto AdaptiveDecodeB(const std::vector<std::uint8_t>& data,
                      std::size_t original_size,
                      const T& max) {
   auto A = std::size_t(max + 1);
@@ -670,16 +669,16 @@ auto AdaptiveDecodeB(const std::vector<uint8_t>& data,
 }
 
 /// \fn AdaptiveDecodeB(const std::pair<
-///                            std::vector<uint8_t>,
+///                            std::vector<std::uint8_t>,
 ///                            std::pair<std::size_t, T>>& pair)
 /// \brief RangeCoder Adaptive Decode Function.
 ///        To solve the zero-frequency-problem, use the Method B.
-/// \param[in] pair \c std::pair of sequence as std::vector<uint8_t> and
+/// \param[in] pair \c std::pair of sequence as std::vector<std::uint8_t> and
 ///            \c std::pair of length of the original sequence as \c std::size_t and
 ///            maximum value of the original sequence
 /// \return original sequence as \c std::vector<T>
 template <typename T>
-auto AdaptiveDecodeB(const std::pair<std::vector<uint8_t>,
+auto AdaptiveDecodeB(const std::pair<std::vector<std::uint8_t>,
                            std::pair<std::size_t, T>>& tuple) {
   return AdaptiveDecodeB(tuple.first, tuple.second.first, tuple.second.second);
 }
@@ -689,7 +688,7 @@ auto AdaptiveDecodeB(const std::pair<std::vector<uint8_t>,
 ///        To solve the zero-frequency-problem, use the Method C.
 /// \param[in] data sequence
 /// \param[in] max maximum value of the data
-/// \return \c std::pair of sequence as \c std::vector<uint8_t> and
+/// \return \c std::pair of sequence as \c std::vector<std::uint8_t> and
 ///         length of the data sequence as \c std::size_t
 template <typename T>
 auto AdaptiveEncodeC(const std::vector<T>& data, const T& max) {
@@ -740,7 +739,7 @@ auto AdaptiveEncodeC(const std::vector<T>& data, const T& max) {
 /// \brief RangeCoder Adaptive Encode Function.
 ///        To solve the zero-frequency-problem, use the Method C.
 /// \param[in] data sequence
-/// \return \c std::pair of sequence as \c std::vector<uint8_t> and
+/// \return \c std::pair of sequence as \c std::vector<std::uint8_t> and
 ///         \c std::pair of length of the original sequence as \c std::size_t and
 ///         maximum value of the original sequence as \c T
 template <typename T>
@@ -757,7 +756,7 @@ auto AdaptiveEncodeC(const std::vector<T>& data) {
                                        std::move(max)));
 }
 
-/// \fn AdaptiveDecodeC(const std::vector<uint8_t>& data,
+/// \fn AdaptiveDecodeC(const std::vector<std::uint8_t>& data,
 ///                    std::size_t original_size,
 ///                    const T& max)
 /// \brief RangeCoder Adaptive Decode Function.
@@ -767,7 +766,7 @@ auto AdaptiveEncodeC(const std::vector<T>& data) {
 /// \param[in] max maximum value of the original sequence
 /// \return original sequence as \c std::vector<T>
 template <typename T>
-auto AdaptiveDecodeC(const std::vector<uint8_t>& data,
+auto AdaptiveDecodeC(const std::vector<std::uint8_t>& data,
                      std::size_t original_size,
                      const T& max) {
   auto A = std::size_t(max + 1);
@@ -820,16 +819,16 @@ auto AdaptiveDecodeC(const std::vector<uint8_t>& data,
 }
 
 /// \fn AdaptiveDecodeC(const std::pair<
-///                            std::vector<uint8_t>,
+///                            std::vector<std::uint8_t>,
 ///                            std::pair<std::size_t, T>>& pair)
 /// \brief RangeCoder Adaptive Decode Function.
 ///        To solve the zero-frequency-problem, use the Method C.
-/// \param[in] pair \c std::pair of sequence as std::vector<uint8_t> and
+/// \param[in] pair \c std::pair of sequence as std::vector<std::uint8_t> and
 ///            \c std::pair of length of the original sequence as \c std::size_t and
 ///            maximum value of the original sequence
 /// \return original sequence as \c std::vector<T>
 template <typename T>
-auto AdaptiveDecodeC(const std::pair<std::vector<uint8_t>,
+auto AdaptiveDecodeC(const std::pair<std::vector<std::uint8_t>,
                            std::pair<std::size_t, T>>& tuple) {
   return AdaptiveDecodeC(tuple.first, tuple.second.first, tuple.second.second);
 }
@@ -839,7 +838,7 @@ auto AdaptiveDecodeC(const std::pair<std::vector<uint8_t>,
 ///        To solve the zero-frequency-problem, use the Method D.
 /// \param[in] data sequence
 /// \param[in] max maximum value of the data
-/// \return \c std::pair of sequence as \c std::vector<uint8_t> and
+/// \return \c std::pair of sequence as \c std::vector<std::uint8_t> and
 ///         length of the data sequence as \c std::size_t
 template <typename T>
 auto AdaptiveEncodeD(const std::vector<T>& data, const T& max) {
@@ -890,7 +889,7 @@ auto AdaptiveEncodeD(const std::vector<T>& data, const T& max) {
 /// \brief RangeCoder Adaptive Encode Function.
 ///        To solve the zero-frequency-problem, use the Method D.
 /// \param[in] data sequence
-/// \return \c std::pair of sequence as \c std::vector<uint8_t> and
+/// \return \c std::pair of sequence as \c std::vector<std::uint8_t> and
 ///         \c std::pair of length of the original sequence as \c std::size_t and
 ///         maximum value of the original sequence as \c T
 template <typename T>
@@ -907,7 +906,7 @@ auto AdaptiveEncodeD(const std::vector<T>& data) {
                                        std::move(max)));
 }
 
-/// \fn AdaptiveDecodeD(const std::vector<uint8_t>& data,
+/// \fn AdaptiveDecodeD(const std::vector<std::uint8_t>& data,
 ///                    std::size_t original_size,
 ///                    const T& max)
 /// \brief RangeCoder Adaptive Decode Function.
@@ -917,7 +916,7 @@ auto AdaptiveEncodeD(const std::vector<T>& data) {
 /// \param[in] max maximum value of the original sequence
 /// \return original sequence as \c std::vector<T>
 template <typename T>
-auto AdaptiveDecodeD(const std::vector<uint8_t>& data,
+auto AdaptiveDecodeD(const std::vector<std::uint8_t>& data,
                      std::size_t original_size,
                      const T& max) {
   auto A = std::size_t(max + 1);
@@ -970,16 +969,16 @@ auto AdaptiveDecodeD(const std::vector<uint8_t>& data,
 }
 
 /// \fn AdaptiveDecodeD(const std::pair<
-///                            std::vector<uint8_t>,
+///                            std::vector<std::uint8_t>,
 ///                            std::pair<std::size_t, T>>& pair)
 /// \brief RangeCoder Adaptive Decode Function.
 ///        To solve the zero-frequency-problem, use the Method D.
-/// \param[in] pair \c std::pair of sequence as std::vector<uint8_t> and
+/// \param[in] pair \c std::pair of sequence as std::vector<std::uint8_t> and
 ///            \c std::pair of length of the original sequence as \c std::size_t and
 ///            maximum value of the original sequence
 /// \return original sequence as \c std::vector<T>
 template <typename T>
-auto AdaptiveDecodeD(const std::pair<std::vector<uint8_t>,
+auto AdaptiveDecodeD(const std::pair<std::vector<std::uint8_t>,
                            std::pair<std::size_t, T>>& tuple) {
   return AdaptiveDecodeD(tuple.first, tuple.second.first, tuple.second.second);
 }

--- a/includes/size-type.h
+++ b/includes/size-type.h
@@ -6,7 +6,7 @@
 #ifndef INCLUDES_SIZE_TYPE_H_
 #define INCLUDES_SIZE_TYPE_H_
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstddef>
 
 /// \namespace ResearchLibrary
@@ -24,22 +24,22 @@ struct size_type;
 /// \privatesection
 template <>
 struct size_type<1> {
-  using type = uint8_t;
+  using type = std::uint8_t;
 };
 
 template <>
 struct size_type<2> {
-  using type = uint16_t;
+  using type = std::uint16_t;
 };
 
 template <>
 struct size_type<4> {
-  using type = uint32_t;
+  using type = std::uint32_t;
 };
 
 template <>
 struct size_type<8> {
-  using type = uint64_t;
+  using type = std::uint64_t;
 };
 
 /// \publicsection
@@ -50,7 +50,7 @@ using size_type_t = typename size_type<N>::type;
 
 /// \var unsigned_integer_size
 /// \brief equals to \c sizeof(unsigned_integer_t).
-constexpr auto unsigned_integer_size = sizeof(ptrdiff_t);
+constexpr auto unsigned_integer_size = sizeof(std::ptrdiff_t);
 
 /// \c unsigned_integer_t declaration.
 using unsigned_integer_t = size_type_t<unsigned_integer_size>;

--- a/includes/size-type.h
+++ b/includes/size-type.h
@@ -18,7 +18,7 @@ namespace ResearchLibrary {
 ///        if the integer equals to \c 1, \c 2, \c 4 or \c 8,
 ///        \c size_type::type will declared
 ///        and \c sizeof(size_type<N>::type) == \c N.
-template <size_t N>
+template <std::size_t N>
 struct size_type;
 
 /// \privatesection
@@ -45,7 +45,7 @@ struct size_type<8> {
 /// \publicsection
 /// \typedef size_type_t
 /// \brief \c size_type_t template declaration
-template <size_t N>
+template <std::size_t N>
 using size_type_t = typename size_type<N>::type;
 
 /// \var unsigned_integer_size

--- a/includes/universal-coding.h
+++ b/includes/universal-coding.h
@@ -32,7 +32,7 @@ namespace UniversalCoding {
 template <typename T>
 auto UnaryCodingEncode(const std::vector<T>& data) {
   BitsToBytes<8> buffer{};
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     for (T value{}; value < data[i]; value++) {
       buffer.put(0, 1);
     }
@@ -42,16 +42,16 @@ auto UnaryCodingEncode(const std::vector<T>& data) {
          std::make_pair(data.size(), T{}));
 }
 
-/// \fn UnaryCodingDecode(const std::vector<uint8_t>& data, size_t length)
+/// \fn UnaryCodingDecode(const std::vector<uint8_t>& data, std::size_t length)
 /// \brief Unary Coding Decode Function
 /// \param[in] data sequence
 /// \param[in] length length of the original sequence
 /// \return original sequence as \c std::vector<T>
 template <typename T>
-auto UnaryCodingDecode(const std::vector<uint8_t>& data, size_t length) {
+auto UnaryCodingDecode(const std::vector<uint8_t>& data, std::size_t length) {
   std::vector<T> ret(length);
   BytesToBits<8> buffer(data);
-  for (size_t i = 0; i < length; i++) {
+  for (std::size_t i = 0; i < length; i++) {
     T value{};
     for (; buffer.get(1) != 1; value++) {}
     ret[i] = std::move(value);
@@ -60,7 +60,7 @@ auto UnaryCodingDecode(const std::vector<uint8_t>& data, size_t length) {
 }
 
 /// \fn UnaryCodingDecode(const std::pair<std::vector<uint8_t>,
-///                             std::pair<size_t, T>>& pair)
+///                             std::pair<std::size_t, T>>& pair)
 /// \brief Unary Coding Decode Function
 /// \param[in] pair \c std::pair of data sequence and
 ///                 \c std::pair of length of the original sequence and
@@ -68,7 +68,7 @@ auto UnaryCodingDecode(const std::vector<uint8_t>& data, size_t length) {
 /// \return original sequence as \c std::vector<T>
 template <typename T>
 auto UnaryCodingDecode(const std::pair<std::vector<uint8_t>,
-                             std::pair<size_t, T>>& tuple) {
+                             std::pair<std::size_t, T>>& tuple) {
   return UnaryCodingDecode<T>(tuple.first, tuple.second.first);
 }
 
@@ -80,7 +80,7 @@ auto UnaryCodingDecode(const std::pair<std::vector<uint8_t>,
 template <typename T>
 auto GammaCodingEncode(const std::vector<T>& data) {
   BitsToBytes<8> buffer{};
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     auto width = static_cast<unsigned_integer_t>(floor(log2(data[i])) + 1);
     buffer.put(0, width - 1);
     for (unsigned_integer_t j = 1; j <= width; j++) {
@@ -91,16 +91,16 @@ auto GammaCodingEncode(const std::vector<T>& data) {
          std::make_pair(data.size(), T{}));
 }
 
-/// \fn GammaCodingDecode(const std::vector<uint8_t>& data, size_t length)
+/// \fn GammaCodingDecode(const std::vector<uint8_t>& data, std::size_t length)
 /// \brief Gamma Coding Decode Function
 /// \param[in] data sequence
 /// \param[in] length length of the original sequence
 /// \return decoded sequence
 template <typename T>
-auto GammaCodingDecode(const std::vector<uint8_t>& data, size_t length) {
+auto GammaCodingDecode(const std::vector<uint8_t>& data, std::size_t length) {
   std::vector<T> ret(length);
   BytesToBits<8> buffer(data);
-  for (size_t i = 0; i < length; i++) {
+  for (std::size_t i = 0; i < length; i++) {
     unsigned_integer_t width = 0;
     for (; buffer.get(1) != 1; width++) {}
     T value = 1;
@@ -113,14 +113,14 @@ auto GammaCodingDecode(const std::vector<uint8_t>& data, size_t length) {
 }
 
 /// \fn GammaCodingDecode(const std::pair<std::vector<uint8_t>,
-///                             std::pair<size_t, T>>& tuple)
+///                             std::pair<std::size_t, T>>& tuple)
 /// \brief Gamma Coding Decode Function
 /// \param[in] tuple \c std::pair of data sequence as \c std::vector<uint8_t>
 ///            and \c std::pair of length of the original sequence and sample
 /// \return decoded sequence
 template <typename T>
 auto GammaCodingDecode(const std::pair<std::vector<uint8_t>,
-                             std::pair<size_t, T>>& tuple) {
+                             std::pair<std::size_t, T>>& tuple) {
   return GammaCodingDecode<T>(tuple.first, tuple.second.first);
 }
 
@@ -132,7 +132,7 @@ auto GammaCodingDecode(const std::pair<std::vector<uint8_t>,
 template <typename T>
 auto DeltaCodingEncode(const std::vector<T>& data) {
   BitsToBytes<8> buffer{};
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     auto width =
       static_cast<unsigned_integer_t>(floor(log2(data[i])) + 1);
     auto width_of_width =
@@ -149,16 +149,16 @@ auto DeltaCodingEncode(const std::vector<T>& data) {
          std::make_pair(data.size(), T{}));
 }
 
-/// \fn DeltaCodingDecode(const std::vector<uint8_t>& data, size_t length)
+/// \fn DeltaCodingDecode(const std::vector<uint8_t>& data, std::size_t length)
 /// \brief Delta Coding Decode Function
 /// \param[in] data sequencee
 /// \param[in] length length of the original sequence
 /// \return decoded sequence
 template <typename T>
-auto DeltaCodingDecode(const std::vector<uint8_t>& data, size_t length) {
+auto DeltaCodingDecode(const std::vector<uint8_t>& data, std::size_t length) {
   std::vector<T> ret(length);
   BytesToBits<8> buffer(data);
-  for (size_t i = 0; i < length; i++) {
+  for (std::size_t i = 0; i < length; i++) {
     unsigned_integer_t width_of_width = 0, width = 1;
     for (; buffer.get(1) != 1; width_of_width++) {}
     for (; width_of_width != 0; width_of_width--) {
@@ -174,14 +174,14 @@ auto DeltaCodingDecode(const std::vector<uint8_t>& data, size_t length) {
 }
 
 /// \fn DeltaCodingDecode(const std::pair<std::vector<uint8_t>,
-///                              std::pair<size_t, T>>& tuple)
+///                              std::pair<std::size_t, T>>& tuple)
 /// \brief Delta Coding Decode Function
 /// \param[in] tuple \c std::pair of data sequence as \c std::vector<uint8_t>
 ///            and \c std::pair of length of the original sequence and sample
 /// \return decoded sequence
 template <typename T>
 auto DeltaCodingDecode(const std::pair<std::vector<uint8_t>,
-                              std::pair<size_t, T>>& tuple) {
+                              std::pair<std::size_t, T>>& tuple) {
   return DeltaCodingDecode<T>(tuple.first, tuple.second.first);
 }
 
@@ -193,7 +193,7 @@ auto DeltaCodingDecode(const std::pair<std::vector<uint8_t>,
 template <typename T>
 auto OmegaCodingEncode(const std::vector<T>& data) {
   BitsToBytes<8> buffer{};
-  for (size_t i = 0; i < data.size(); i++) {
+  for (std::size_t i = 0; i < data.size(); i++) {
     std::vector<T> buffer2{0};
     auto n = data[i];
     while (n != 1) {
@@ -215,21 +215,21 @@ auto OmegaCodingEncode(const std::vector<T>& data) {
          std::make_pair(data.size(), T{}));
 }
 
-/// \fn OmegaCodingDecode(const std::vector<uint8_t>& data, size_t length)
+/// \fn OmegaCodingDecode(const std::vector<uint8_t>& data, std::size_t length)
 /// \brief Omega Coding Decode Function
 /// \param[in] data sequence
 /// \param[in] length length of the original sequence
 /// \return decoded sequence
 template <typename T>
-auto OmegaCodingDecode(const std::vector<uint8_t>& data, size_t length) {
+auto OmegaCodingDecode(const std::vector<uint8_t>& data, std::size_t length) {
   std::vector<T> ret(length);
   BytesToBits<8> buffer(data);
-  for (size_t i = 0; i < length; i++) {
+  for (std::size_t i = 0; i < length; i++) {
     size_type_t<8> n = 1;
     while (buffer.get(1) != 0) {
       auto width = n;
       n = 1;
-      for (size_t j = 0; j < width; j++) {
+      for (std::size_t j = 0; j < width; j++) {
         n = (n << 1) + buffer.get(1);
       }
     }
@@ -239,14 +239,14 @@ auto OmegaCodingDecode(const std::vector<uint8_t>& data, size_t length) {
 }
 
 /// \fn OmegaCodingDecode(const std::pair<std::vector<uint8_t>,
-///                              std::pair<size_t, T>>& tuple)
+///                              std::pair<std::size_t, T>>& tuple)
 /// \brief Omega Coding Decode Function
 /// \param[in] tuple \c std::pair of data sequence as \c std::vector<uint8_t>
 ///            and \c std::pair of length of the original sequence and sample
 /// \return decoded sequence
 template <typename T>
 auto OmegaCodingDecode(const std::pair<std::vector<uint8_t>,
-                              std::pair<size_t, T>>& tuple) {
+                              std::pair<std::size_t, T>>& tuple) {
   return OmegaCodingDecode<T>(tuple.first, tuple.second.first);
 }
 
@@ -261,7 +261,7 @@ auto GolombCodingEncode(const std::vector<T>& data, T m) {
   BitsToBytes<8> buffer{};
   auto b = T(ceil(log2(m)));
   if ((m & (m - 1)) == 0) {
-    for (size_t i = 0; i < data.size(); i++) {
+    for (std::size_t i = 0; i < data.size(); i++) {
       auto d = data[i];
       auto q = d / m;
       auto r = d % m;
@@ -276,7 +276,7 @@ auto GolombCodingEncode(const std::vector<T>& data, T m) {
   } else {
     auto bb = (T(1) << b) - m;
     auto c = b - 1;
-    for (size_t i = 0; i < data.size(); i++) {
+    for (std::size_t i = 0; i < data.size(); i++) {
       auto d = data[i];
       auto q = d / m;
       auto r = d % m;
@@ -302,7 +302,7 @@ auto GolombCodingEncode(const std::vector<T>& data, T m) {
 
 /// \fn GolombCodingDecode(const std::vector<uint8_t>& data,
 ///                         const T& m,
-///                         size_t length)
+///                         std::size_t length)
 /// \brief Golomb Coding Decode Function
 /// \param[in] data sequence
 /// \param[in] m positive integer
@@ -311,12 +311,12 @@ auto GolombCodingEncode(const std::vector<T>& data, T m) {
 template <typename T>
 auto GolombCodingDecode(const std::vector<uint8_t>& data,
                          const T& m,
-                         size_t length) {
+                         std::size_t length) {
   std::vector<T> ret(length);
   BytesToBits<8> buffer(data);
   auto b = T(ceil(log2(m)));
   if ((m & (m - 1)) == 0) {
-    for (size_t i = 0; i < length; i++) {
+    for (std::size_t i = 0; i < length; i++) {
       T q{}, r{};
       for (; buffer.get(1) != 1; q++) {}
       for (T j = 1; j <= b; j++) {
@@ -327,7 +327,7 @@ auto GolombCodingDecode(const std::vector<uint8_t>& data,
   } else {
     auto bb = (T(1) << b) - m;
     auto c = b - 1;
-    for (size_t i = 0; i < length; i++) {
+    for (std::size_t i = 0; i < length; i++) {
       T q{}, r{};
       for (; buffer.get(1) != 1; q++) {}
       for (T j = 1; j <= c; j++) {
@@ -344,7 +344,7 @@ auto GolombCodingDecode(const std::vector<uint8_t>& data,
 }
 
 /// \fn GolombCodingDecode(const std::pair<std::vector<uint8_t>,
-///                               std::pair<size_t, T>>& tuple,
+///                               std::pair<std::size_t, T>>& tuple,
 ///                         const T& m)
 /// \brief Golomb Coding Decode Function
 /// \param[in] tuple \c std::pair of sequence and \c std::pair of length
@@ -353,7 +353,7 @@ auto GolombCodingDecode(const std::vector<uint8_t>& data,
 /// \return decoded sequence
 template <typename T>
 auto GolombCodingDecode(const std::pair<std::vector<uint8_t>,
-                               std::pair<size_t, T>>& tuple,
+                               std::pair<std::size_t, T>>& tuple,
                          const T& m) {
   return GolombCodingDecode<T>(tuple.first, m, tuple.second.first);
 }

--- a/includes/universal-coding.h
+++ b/includes/universal-coding.h
@@ -6,8 +6,7 @@
 #ifndef INCLUDES_UNIVERSAL_CODING_H_
 #define INCLUDES_UNIVERSAL_CODING_H_
 
-#include <math.h>
-
+#include <cmath>
 #include <vector>
 #include <utility>
 
@@ -81,7 +80,7 @@ template <typename T>
 auto GammaCodingEncode(const std::vector<T>& data) {
   BitsToBytes<8> buffer{};
   for (std::size_t i = 0; i < data.size(); i++) {
-    auto width = static_cast<unsigned_integer_t>(floor(log2(data[i])) + 1);
+    auto width = static_cast<unsigned_integer_t>(std::floor(std::log2(data[i])) + 1);
     buffer.put(0, width - 1);
     for (unsigned_integer_t j = 1; j <= width; j++) {
       buffer.put(static_cast<size_type_t<8>>(data[i]) >> (width - j), 1);
@@ -134,9 +133,9 @@ auto DeltaCodingEncode(const std::vector<T>& data) {
   BitsToBytes<8> buffer{};
   for (std::size_t i = 0; i < data.size(); i++) {
     auto width =
-      static_cast<unsigned_integer_t>(floor(log2(data[i])) + 1);
+      static_cast<unsigned_integer_t>(std::floor(std::log2(data[i])) + 1);
     auto width_of_width =
-      static_cast<unsigned_integer_t>(floor(log2(width)) + 1);
+      static_cast<unsigned_integer_t>(std::floor(std::log2(width)) + 1);
     buffer.put(0, width_of_width - 1);
     for (unsigned_integer_t j = 1; j <= width_of_width; j++) {
       buffer.put(width >> (width_of_width - j), 1);
@@ -198,14 +197,14 @@ auto OmegaCodingEncode(const std::vector<T>& data) {
     auto n = data[i];
     while (n != 1) {
       buffer2.push_back(n);
-      n = static_cast<T>(floor(log2(n)));
+      n = static_cast<T>(std::floor(std::log2(n)));
     }
     for (auto it = buffer2.rbegin();; ++it) {
       if (*it == 0) {
         buffer.put(0, 1);
         break;
       }
-      auto width = static_cast<unsigned_integer_t>(floor(log2(*it)) + 1);
+      auto width = static_cast<unsigned_integer_t>(std::floor(std::log2(*it)) + 1);
       for (unsigned_integer_t j = 1; j <= width; j++) {
         buffer.put(static_cast<size_type_t<8>>(*it >> (width - j)), 1);
       }
@@ -259,7 +258,7 @@ auto OmegaCodingDecode(const std::pair<std::vector<uint8_t>,
 template <typename T>
 auto GolombCodingEncode(const std::vector<T>& data, T m) {
   BitsToBytes<8> buffer{};
-  auto b = T(ceil(log2(m)));
+  auto b = T(std::ceil(std::log2(m)));
   if ((m & (m - 1)) == 0) {
     for (std::size_t i = 0; i < data.size(); i++) {
       auto d = data[i];
@@ -314,7 +313,7 @@ auto GolombCodingDecode(const std::vector<uint8_t>& data,
                          std::size_t length) {
   std::vector<T> ret(length);
   BytesToBits<8> buffer(data);
-  auto b = T(ceil(log2(m)));
+  auto b = T(std::ceil(std::log2(m)));
   if ((m & (m - 1)) == 0) {
     for (std::size_t i = 0; i < length; i++) {
       T q{}, r{};


### PR DESCRIPTION
dictionary.erase(it) の後に w は無効な要素への参照となるため push_front が先に行われるべきです。
また、w の値はそれ以降参照されなくなるため、move したほうがよいです。
